### PR TITLE
Add purpose-based project workspaces and agent onboarding

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,9 +8,9 @@
 
 ## Vision
 
-For indie founders, developer advocates, and small marketers who know Reddit is where their users hang out — but can’t spend hours browsing threads, and won’t run a spam bot that gets them banned.
+For indie founders, developer advocates, and people who want to show up on Reddit as themselves — who know the right threads are out there, but can’t spend hours browsing, and won’t run a spam bot that gets them banned.
 
-**Job to be done:** Continuously find threads where people want (or need) what you offer → you pick what to engage → draft replies in your voice → edit and post now or schedule safely.
+**Job to be done:** Continuously find threads that match what this workspace is for (a product, you as a person, or a custom aim) → you pick what to engage → draft in that workspace’s voice → edit and post now or schedule safely.
 
 **Why now:** GummySearch is gone (thread/intent discovery vacuum), Reddit’s API is tighter, LLMs are good enough that your job is judgment not typing — and local OSS with *your* Reddit OAuth tokens is one of the few lanes Reddit still leaves open.
 
@@ -18,7 +18,7 @@ For indie founders, developer advocates, and small marketers who know Reddit is 
 
 ## Positioning
 
-**One-liner:** It finds intent threads for you. You add the ones worth answering, draft in your voice, and nothing posts until you hit Post or Schedule.
+**One-liner:** It finds intent threads for the workspace you’re in. You add the ones worth answering, draft in that voice, and nothing posts until you hit Post or Schedule.
 
 **Category:** Human-in-the-loop Reddit engagement assistant — with autonomous discovery and on-demand drafting (open source, local-first).
 
@@ -39,7 +39,7 @@ For indie founders, developer advocates, and small marketers who know Reddit is 
 
 | Need | Decision | How it shows up |
 |------|----------|-----------------|
-| **1. Find threads where people want my product** | **Build** | Intent discovery, keyword/topic filters, question radar → Discover triage |
+| **1. Find threads that match this workspace** | **Build** | Briefing-driven intent discovery, keyword/topic filters, question radar → Discover triage |
 | **2. AI drafts replies, human posts** | **Build (core)** | Add to queue → Draft/Regenerate (streamed) → edit → Post or Schedule; nothing ships without you |
 | **3. Keyword / brand alerts** | **Skip** | No always-on “ping me forever” monitoring inbox — leave that to Syften |
 | **4. Schedule Reddit posts** | **Build** | Schedule a drafted reply for later — the scheduler is a delay, not autopilot |
@@ -62,26 +62,28 @@ For indie founders, developer advocates, and small marketers who know Reddit is 
 
 | Persona | Goal | Pain | Success |
 |--------|------|------|---------|
-| **Maya** — indie SaaS founder | 3–5 helpful comments/week in niche + founder subs | Opens Reddit “for 10 min,” loses an hour; can’t find buying-intent threads | Discover fills with intent threads; 15-min weekly Add → Draft → Post; some become DMs/signups; replies scheduled for peak hours |
-| **Dev** — developer advocate | Be the helpful expert without sounding corporate | Closed $49/mo tools store Reddit creds on someone else’s server | Runs locally, voice matches him, audit log for his manager |
-| **Priya** — solo marketer (2 clients) | Find intent threads per client, reply from the right account, prove value | Account switching + no tracking + posting at bad times | Per-account queues, scheduled sends, monthly outcomes export |
+| **Maya** — indie SaaS founder | 3–5 helpful comments/week in niche + founder subs | Opens Reddit “for 10 min,” loses an hour; can’t find buying-intent threads | A **product** workspace fills Discover; 15-min weekly Add → Draft → Post; some become DMs/signups; replies scheduled for peak hours |
+| **Dev** — developer advocate | Be the helpful expert without sounding corporate | Closed $49/mo tools store Reddit creds on someone else’s server | Runs locally; a workspace briefing matches how he talks; audit log for his manager |
+| **Alex** — IC / job seeker | Show up as yourself in career and hobby subs | “Product voice” makes personal comments feel like ads | A **personal** workspace; drafts sound like them, not a company |
+| **Priya** — solo marketer (2 clients) | Find intent threads per client, prove value | One voice/config for everything; no tracking; posting at bad times | One **workspace per client**; scheduled sends; monthly outcomes export |
 
 ---
 
 ## Core loop
 
 ```
-Discover (auto) → Triage → Add / Skip (human) → Draft / Edit (human + LLM) → Post now | Schedule → Learn → Digest
+Workspace briefing → Discover (auto) → Triage → Add / Skip → Draft / Edit → Post now | Schedule | Original post → Learn → Digest
 ```
 
-Users live in **Discover + the review queue**, not on reddit.com.
+Users live in **Discover + the review queue**, not on reddit.com. Reddit sign-in and the LLM key are **account-level**. Each **workspace** (product, personal, or custom) has its own briefing, goals, subreddits, drafts, and queue.
 
-1. **Discover (autonomous)** — continuously pull threads that match product/intent signals (subs, keywords, unanswered questions).
-2. **Triage** — rank and hide noise in Discover.
-3. **Add / Skip (human)** — pick which threads enter the review queue; skip the rest.
-4. **Draft / Edit (human + LLM)** — generate a streamed reply in your voice, edit it, regenerate if needed. Reject anything that doesn’t fit.
-5. **Post now or schedule** — the only hard gate before anything reaches Reddit; scheduler is a delay, not autopilot.
-6. **Learn + digest** — outcomes improve discovery/drafts; weekly summary pulls the user back.
+1. **Brief once** — pick a purpose, talk to the onboarding agent (links welcome). Copilot proposes a name, briefing, goals, communities, and keywords; you edit, then it fetches.
+2. **Discover (autonomous)** — pull threads that match *this workspace’s* briefing and intent signals (subs, keywords, unanswered questions).
+3. **Triage** — rank and hide noise in Discover.
+4. **Add / Skip (human)** — pick which threads enter the review queue; skip the rest.
+5. **Draft / Edit (human + LLM)** — generate a streamed reply in the workspace voice, edit it, regenerate if needed. Reject anything that doesn’t fit.
+6. **Post now, schedule, or compose** — the only hard gate before anything reaches Reddit; scheduler is a delay, not autopilot. Original self-posts use the same gate.
+7. **Learn + digest** — outcomes improve discovery/drafts; weekly summary pulls the user back.
 
 ---
 
@@ -91,35 +93,34 @@ Users live in **Discover + the review queue**, not on reddit.com.
 
 | Feature | Pillar | Why it matters |
 |--------|--------|----------------|
-| **Intent / keyword thread discovery** | 1 | Find threads where people ask for problems your product solves (GummySearch gap) |
+| **Purpose-based workspaces** | 2 | Product, personal, or custom — each with its own briefing, goals, subs, drafts, and queue |
+| **Agent briefing interview** | 2 | Short chat (paste links) → proposed workspace you can edit; agent advances when it has enough |
+| **Intent / keyword thread discovery** | 1 | Find threads that match this workspace (GummySearch gap) |
 | **Autonomous fetch + Discover triage** | 1 | Background fetch fills Discover — Polsia “it runs” feel without auto-post |
-| **Relevance scoring & triage** | 1 | Rank by fit; hide noise so Add/Skip is fast |
-| **Voice / persona config** | 2 | “Describe your product + tone once” — generic LLM comments get downvoted |
+| **Relevance scoring & intent labels** | 1 | Rank by fit; tag question / looking-for-tool / complaint / unanswered so Add/Skip is fast |
 | **Add → Draft → Post review UI** | 2 | Queue threads, stream draft/regenerate, edit, reject, post/schedule — review *is* the product |
+| **Original self-posts** | 2 | Write or generate a post, then post now or schedule — same human gate |
 | **Safe posting guardrails** | 2 | Rate limits, cooldowns, no double-reply, allowlists |
-| **Schedule drafted comments** | 4 | Queue a drafted reply for a future time |
+| **Schedule drafted comments & posts** | 4 | Queue a drafted reply or self-post for a future time; best-time hints per sub |
+| **Outcome tracking** | 2 | Poll posted comments for score, replies, removals |
 | **Audit log** | 2 | Every queue, draft, edit, post, schedule event in SQLite |
-| **5-minute onboarding** | 2 | `rcopilot init` works cold on a fresh machine |
+| **Local onboarding** | 2 | Connect Reddit + LLM once; then purpose → interview → review → first fetch |
 
 ### P1 — Differentiate (OSS v1.x)
 
 | Feature | Pillar | Why |
 |--------|--------|-----|
-| **Question radar** | 1 | Unanswered questions = highest-value intent threads |
-| **Buying-intent / problem labels** | 1 | Tag threads (question, complaint, looking-for-tool) for fast scan |
-| **Outcome tracking** | 2 | Upvotes / replies / removals → “this worked” |
+| **Question radar** | 1 | Dedicated unanswered-first surface (labels already exist) |
 | **Draft variants** | 2 | 2–3 angles per thread; pick instead of rewrite |
 | **Weekly digest** | 2 | Found / drafted / posted / outcomes (Slack/email webhook) — not brand alerts |
-| **Schedule drafted posts** | 4 | Same draft-then-schedule flow for original posts |
-| **Best-time suggestions** | 4 | Simple local heuristics for sub activity windows |
-| **Local LLM (Ollama)** | 2 | Private, free drafting |
-| **Multi-account routing** | 2 | Per-account subs, voice, queues, schedules |
+| **Local LLM (Ollama) as a first-class path** | 2 | Private drafting without a cloud key (base_url already works) |
+| **Multi-account routing** | 2 | Per-Reddit-account queues and schedules (workspaces already split *aims*) |
 
 ### P2 — Compound (OSS v2)
 
 | Feature | Pillar | Why |
 |--------|--------|-----|
-| **Saved discovery searches** | 1 | Reusable “find threads like this” per product/client |
+| **Saved discovery searches** | 1 | Reusable “find threads like this” inside a workspace |
 | **Reply follow-ups** | 2 | Draft follow-ups when someone replies to you (still human publish) |
 | **Draft memory** | 2 | Learn from edits/rejections over time |
 | **Export & reporting** | 2 | Client / team reports |
@@ -177,8 +178,8 @@ Same loop. Human still chooses every publish. Cloud hosts the worker, not the ju
 
 | Phase | Weeks | Focus | Exit criteria |
 |------|-------|-------|---------------|
-| **1 — Revival** | 1–4 | P0: auto discover + Add/Skip + streamed draft review + schedule + docs/demo | Cold quickstart works; 10 external users posted or scheduled via the tool; Show HN / r/SideProject |
-| **2 — Differentiate** | 5–10 | Question radar, intent labels, outcomes, variants, digest, schedule posts, Ollama | ≥40% post rate from queued threads; 50 WAU; 3 “switched from X” notes |
+| **1 — Revival** | 1–4 | P0: workspaces + agent briefing + auto discover + Add/Skip + streamed draft review + original posts + schedule + docs/demo | Cold quickstart works; 10 external users posted or scheduled via the tool; Show HN / r/SideProject |
+| **2 — Differentiate** | 5–10 | Question radar, variants, digest, first-class Ollama, multi-account | ≥40% post rate from queued threads; 50 WAU; 3 “switched from X” notes |
 | **3 — Compound** | 11–18 | Saved searches, follow-ups, memory, calendar, plugins, export | 100 WAU; community PRs; cloud waitlist ≥200 |
 | **4 — Cloud alpha** | 19–28 | Hosted discover/schedule runner + mobile review; paid from day one | 20 paying users; no ToS incidents; decide continue vs OSS-only |
 
@@ -197,9 +198,9 @@ Same loop. Human still chooses every publish. Cloud hosts the worker, not the ju
 | HTTP API | **FastAPI** | JSON + SSE for the Next app; replaces Flask UI routes |
 | Reddit API | **PRAW** + web-app OAuth (refresh token) | Browser Connect Reddit; no password; local `.env` |
 | LLM | **OpenAI-compatible HTTP** (`openai` SDK) | OpenAI / Groq / OpenRouter / **Ollama** via `base_url`; streamed drafts |
-| Storage | **SQLite** | Zero ops; posts, drafts, audit, schedule queue |
+| Storage | **SQLite** | Zero ops; workspaces, posts, drafts, audit, schedule queue |
 | Config | `config.yaml` **+** `.env` | Non-secrets vs secrets; gitignore-safe |
-| Frontend | **Next.js (App Router) + TypeScript** | Discover, review queue, streaming draft, schedule — same UI path as cloud |
+| Frontend | **Next.js (App Router) + TypeScript** | Workspaces, Discover, review queue, streaming draft, schedule — same UI path as cloud |
 | Autonomy worker | **CLI daemon** (`rcopilot run`) or cron | Discover + due schedules; drafting is on-demand in the UI |
 | Scheduler | **SQLite due jobs + worker tick** | Drafted items with `run_at`; no Celery yet |
 | Local DX | `rcopilot serve` starts API; `npm run dev` in `web/` for UI (or a small compose script) | Two processes is fine for OSS |
@@ -239,17 +240,17 @@ web/               # Next.js review app
 ```
 ┌──────────────┐     ┌──────────────┐     ┌─────────────┐
 │ CLI / worker │────▶│  pipeline    │────▶│  SQLite     │
-│ rcopilot run │     │  discover    │     │  posts      │
-└──────────────┘     │  post/sched  │     │  drafts     │
-                     │              │     │  jobs/audit │
-┌──────────────┐     └──────┬───────┘     └──────▲──────┘
-│ Next.js web/ │            │                    │
-│ Discover +   │──── JSON ──┤                    │
+│ rcopilot run │     │  discover    │     │  workspaces │
+└──────────────┘     │  post/sched  │     │  posts      │
+                     │              │     │  drafts     │
+┌──────────────┐     └──────┬───────┘     │  jobs/audit │
+│ Next.js web/ │            │             └──────▲──────┘
+│ workspaces + │──── JSON ──┤                    │
 │ review UI    │──── SSE ───┤                    │
 └──────────────┘            │                    │
                      ┌──────▼───────┐     ┌──────┴──────┐
                      │  FastAPI     │     │  PRAW + LLM │
-                     │  /api/*      │     │  (on-demand │
+                     │  /api/*      │     │  (briefing, │
                      └──────────────┘     │   draft)    │
                                           └─────────────┘
 ```
@@ -276,12 +277,13 @@ web/               # Next.js review app
 
 ## Final recommendation (locked)
 
-Ship **Phase 1 around Maya**:
+Ship **Phase 1 around Maya’s product workspace**, without locking everyone into “a company”:
 
-1. **Autonomous discover** of intent threads
-2. **Human Add / Skip** into a review queue
-3. **On-demand Draft** (streamed) → **edit** → **Post now or Schedule**
+1. **Workspace briefing** (purpose + agent interview) so discovery and drafts know what this copilot is for
+2. **Autonomous discover** of intent threads for that workspace
+3. **Human Add / Skip** into a review queue
+4. **On-demand Draft** (streamed) → **edit** → **Post now, Schedule, or compose an original post**
 
 Skip brand alerts. Skip full autonomous posting. Skip auto-drafting every matched thread.
 
-**Product in one sentence:** An autonomous Reddit discovery pipeline with on-demand drafting and a human publish gate.
+**Product in one sentence:** An autonomous Reddit discovery pipeline, scoped to a workspace you brief once, with on-demand drafting and a human publish gate.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,7 @@ worker:
 
 onboarding_complete: false
 onboarding_step: 0
+active_project_id: ""
 
 # Must match the Reddit web app redirect URI exactly
 oauth_redirect_uri: http://127.0.0.1:8000/api/oauth/callback

--- a/rcopilot/api.py
+++ b/rcopilot/api.py
@@ -177,6 +177,7 @@ class ProjectUpdateBody(BaseModel):
     subreddits: list[str] | None = None
     keywords: list[str] | None = None
     complete: bool | None = None
+    setup_step: int | None = None
 
 
 class ActiveProjectBody(BaseModel):
@@ -283,6 +284,8 @@ def create_app(config_path: str | None = None) -> FastAPI:
         data["onboarding_complete"] = bool(
             config.onboarding_complete and has_finished_project(store)
         )
+        setup = store.find_setup_project()
+        data["setup_project"] = serialize_project(setup) if setup else None
         return data
 
     @app.on_event("startup")
@@ -821,7 +824,11 @@ def create_app(config_path: str | None = None) -> FastAPI:
             name=(body.name or "").strip(),
             interview_messages=[opening],
         )
-        return serialize_project(project)
+        for item in store.list_projects(include_empty=True):
+            if item["id"] != project["id"] and int(item.get("setup_step") or 0) in {3, 4, 5}:
+                store.update_project(item["id"], setup_step=0)
+        updated = store.update_project(project["id"], setup_step=4)
+        return serialize_project(updated or project)
 
     @app.put("/api/projects/active")
     def set_active_project(body: ActiveProjectBody) -> dict[str, Any]:
@@ -858,6 +865,10 @@ def create_app(config_path: str | None = None) -> FastAPI:
                 fields[key] = value
         if body.complete is not None:
             fields["complete"] = body.complete
+            if body.complete:
+                fields["setup_step"] = 0
+        if body.setup_step is not None:
+            fields["setup_step"] = body.setup_step
         updated = store.update_project(project_id, **fields) if fields else project
         if updated is None:
             raise HTTPException(status_code=404, detail="Project not found")
@@ -949,6 +960,7 @@ def create_app(config_path: str | None = None) -> FastAPI:
             persona=briefing.get("persona") or "",
             avoid=briefing.get("avoid") or "",
             subreddits=briefing.get("subreddits") or [],
+            setup_step=5,
         )
         if updated is None:
             raise HTTPException(status_code=404, detail="Project not found")

--- a/rcopilot/api.py
+++ b/rcopilot/api.py
@@ -32,6 +32,12 @@ from rcopilot.config import (
 )
 from rcopilot import reddit_client
 from rcopilot.draft_lint import lint_draft
+from rcopilot.interview import (
+    attach_user_turn,
+    complete_workspace,
+    iter_interview_reply,
+    opening_message,
+)
 from rcopilot.pipeline import (
     approve_draft,
     cancel_schedule,
@@ -52,7 +58,16 @@ from rcopilot.pipeline import (
     schedule_draft,
     skip_post,
 )
-from rcopilot.store import Store
+from rcopilot.store import DEFAULT_PROJECT_ID, PROJECT_PURPOSES, Store
+from rcopilot.projects import (
+    apply_project_to_config,
+    has_finished_project,
+    persist_config_to_project,
+    resolve_active_project,
+    seed_projects_from_config,
+    serialize_project,
+    serialize_project_summary,
+)
 from rcopilot.best_times import (
     get_cached_hours,
     set_cached_hours,
@@ -123,6 +138,8 @@ class SuggestSubredditsBody(BaseModel):
     tone: str | None = None
     persona: str | None = None
     count: int = 12
+    purpose: str | None = None
+    goals: list[str] | None = None
 
 
 class ConfigUpdateBody(BaseModel):
@@ -138,6 +155,34 @@ class ConfigUpdateBody(BaseModel):
     prompt_template: str | None = None
     onboarding_complete: bool | None = None
     onboarding_step: int | None = None
+    active_project_id: str | None = None
+    purpose: str | None = None
+    goals: list[str] | None = None
+
+
+class ProjectCreateBody(BaseModel):
+    purpose: str
+    name: str | None = None
+
+
+class ProjectUpdateBody(BaseModel):
+    name: str | None = None
+    briefing: str | None = None
+    goals: list[str] | None = None
+    tone: str | None = None
+    persona: str | None = None
+    avoid: str | None = None
+    subreddits: list[str] | None = None
+    keywords: list[str] | None = None
+    complete: bool | None = None
+
+
+class ActiveProjectBody(BaseModel):
+    id: str
+
+
+class InterviewBody(BaseModel):
+    message: str
 
 
 class SecretsBody(BaseModel):
@@ -211,12 +256,32 @@ def create_app(config_path: str | None = None) -> FastAPI:
     def get_config() -> AppConfig:
         if not resolved_path.exists():
             raise HTTPException(status_code=400, detail=f"Config not found: {resolved_path}")
-        return load_config(resolved_path)
+        config = load_config(resolved_path)
+        store = Store(config.db_path)
+        store.ensure_schema()
+        seed_projects_from_config(store, config)
+        project = resolve_active_project(store, config)
+        if project:
+            apply_project_to_config(config, project)
+        return config
 
     def get_store(config: AppConfig) -> Store:
         store = Store(config.db_path)
         store.ensure_schema()
+        seed_projects_from_config(store, config)
         return store
+
+    def _pid(config: AppConfig) -> str:
+        return (config.active_project_id or "").strip() or DEFAULT_PROJECT_ID
+
+    def _public_config(config: AppConfig) -> dict[str, Any]:
+        store = get_store(config)
+        data = sanitize_config(config)
+        data["projects"] = [serialize_project_summary(item) for item in store.list_projects()]
+        data["onboarding_complete"] = bool(
+            config.onboarding_complete and has_finished_project(store)
+        )
+        return data
 
     @app.on_event("startup")
     def on_startup() -> None:
@@ -233,7 +298,7 @@ def create_app(config_path: str | None = None) -> FastAPI:
     def status() -> dict[str, Any]:
         config = get_config()
         store = get_store(config)
-        counts = store.count_drafts_by_status()
+        counts = store.count_drafts_by_status(project_id=_pid(config))
         return {
             "counts": {
                 "pending": counts.get("pending", 0),
@@ -253,7 +318,7 @@ def create_app(config_path: str | None = None) -> FastAPI:
         config = get_config()
         store = get_store(config)
         filter_status = None if status == "all" else status
-        drafts = store.list_drafts(status=filter_status)
+        drafts = store.list_drafts(status=filter_status, project_id=_pid(config))
         return {"drafts": [_serialize_draft(d, product=config.voice.product) for d in drafts]}
 
     @app.get("/api/drafts/{draft_id}")
@@ -416,6 +481,7 @@ def create_app(config_path: str | None = None) -> FastAPI:
         config = get_config()
         store = get_store(config)
         posts = store.list_posts(
+            project_id=_pid(config),
             undrafted=undrafted if undrafted else None,
             skipped=skipped,
             min_score=config.discovery.min_score if undrafted else None,
@@ -458,10 +524,10 @@ def create_app(config_path: str | None = None) -> FastAPI:
         config = get_config()
         store = get_store(config)
         try:
-            skip_post(store, post_id)
+            skip_post(store, post_id, project_id=_pid(config))
         except ValueError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        post = store.get_post(post_id)
+        post = store.get_post(post_id, project_id=_pid(config))
         return _serialize_post(post)  # type: ignore[arg-type]
 
     @app.post("/api/actions/fetch")
@@ -562,6 +628,8 @@ def create_app(config_path: str | None = None) -> FastAPI:
                 tone=tone or "",
                 persona=persona or "",
                 count=body.count,
+                purpose=body.purpose or config.purpose,
+                goals=body.goals if body.goals is not None else config.goals,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -637,20 +705,20 @@ def create_app(config_path: str | None = None) -> FastAPI:
     def get_schedule() -> dict[str, Any]:
         config = get_config()
         store = get_store(config)
-        drafts = store.list_scheduled()
+        drafts = store.list_scheduled(project_id=_pid(config))
         return {"drafts": [_serialize_draft(d, product=config.voice.product) for d in drafts]}
 
     @app.get("/api/activity")
     def get_activity(limit: int = Query(default=100, ge=1, le=500)) -> dict[str, Any]:
         config = get_config()
         store = get_store(config)
-        events = store.list_audit(limit=limit)
+        events = store.list_audit(limit=limit, project_id=_pid(config))
         return {"events": events}
 
     @app.get("/api/config")
     def get_config_route() -> dict[str, Any]:
         config = get_config()
-        return sanitize_config(config)
+        return _public_config(config)
 
     @app.put("/api/config")
     def put_config(body: ConfigUpdateBody) -> dict[str, Any]:
@@ -713,10 +781,194 @@ def create_app(config_path: str | None = None) -> FastAPI:
         if body.onboarding_complete is not None:
             config.onboarding_complete = body.onboarding_complete
         if body.onboarding_step is not None:
-            config.onboarding_step = max(0, min(int(body.onboarding_step), 4))
+            config.onboarding_step = max(0, min(int(body.onboarding_step), 5))
+        if body.active_project_id is not None:
+            config.active_project_id = body.active_project_id
+        if body.purpose is not None:
+            config.purpose = body.purpose
+        if body.goals is not None:
+            config.goals = [str(item) for item in body.goals if str(item).strip()]
 
         save_config(resolved_path, config)
-        return sanitize_config(config)
+        if any(
+            value is not None
+            for value in (body.subreddits, body.voice, body.discovery, body.goals, body.purpose)
+        ):
+            persist_config_to_project(get_store(config), config)
+        return _public_config(config)
+
+    @app.get("/api/projects")
+    def list_projects() -> dict[str, Any]:
+        config = get_config()
+        store = get_store(config)
+        return {
+            "projects": [serialize_project_summary(item) for item in store.list_projects()],
+            "active_project_id": _pid(config),
+        }
+
+    @app.post("/api/projects")
+    def create_project_route(body: ProjectCreateBody) -> dict[str, Any]:
+        purpose = (body.purpose or "").strip().lower()
+        if purpose not in PROJECT_PURPOSES:
+            raise HTTPException(status_code=400, detail="Purpose must be product, personal, or custom.")
+        config = get_config()
+        store = get_store(config)
+        opening = opening_message(purpose)
+        project = store.create_project(
+            purpose=purpose,
+            name=(body.name or "").strip(),
+            interview_messages=[opening],
+        )
+        return serialize_project(project)
+
+    @app.put("/api/projects/active")
+    def set_active_project(body: ActiveProjectBody) -> dict[str, Any]:
+        config = get_config()
+        store = get_store(config)
+        project = store.get_project(body.id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        config.active_project_id = project["id"]
+        apply_project_to_config(config, project)
+        save_config(resolved_path, config)
+        return _public_config(config)
+
+    @app.get("/api/projects/{project_id}")
+    def get_project_route(project_id: str) -> dict[str, Any]:
+        config = get_config()
+        store = get_store(config)
+        project = store.get_project(project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        return serialize_project(project)
+
+    @app.patch("/api/projects/{project_id}")
+    def patch_project_route(project_id: str, body: ProjectUpdateBody) -> dict[str, Any]:
+        config = get_config()
+        store = get_store(config)
+        project = store.get_project(project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        fields: dict[str, Any] = {}
+        for key in ("name", "briefing", "goals", "tone", "persona", "avoid", "subreddits", "keywords"):
+            value = getattr(body, key)
+            if value is not None:
+                fields[key] = value
+        if body.complete is not None:
+            fields["complete"] = body.complete
+        updated = store.update_project(project_id, **fields) if fields else project
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if body.complete or config.active_project_id == project_id:
+            config.active_project_id = project_id
+            apply_project_to_config(config, updated)
+            save_config(resolved_path, config)
+        return serialize_project(updated)
+
+    @app.post("/api/projects/{project_id}/interview")
+    def interview_project(project_id: str, body: InterviewBody) -> StreamingResponse:
+        config = get_config()
+        store = get_store(config)
+        project = store.get_project(project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if not config.llm.api_key:
+            raise HTTPException(status_code=400, detail="Add an LLM API key first.")
+        text = (body.message or "").strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="Write a message first.")
+
+        messages, researched = attach_user_turn(list(project.get("interview_messages") or []), text)
+        store.update_project(project_id, interview_messages=messages, links=_merge_links(project, researched))
+
+        def event_stream() -> Iterator[str]:
+            parts: list[str] = []
+            try:
+                if researched:
+                    yield f"data: {json.dumps({'research': researched})}\n\n"
+                for delta in iter_interview_reply(
+                    config.llm,
+                    purpose=project.get("purpose") or "custom",
+                    messages=messages,
+                ):
+                    parts.append(delta)
+                    yield f"data: {json.dumps({'delta': delta})}\n\n"
+                reply = "".join(parts).strip()
+                history = list(messages)
+                history.append({"role": "assistant", "content": reply})
+                store.update_project(project_id, interview_messages=history)
+                yield f"data: {json.dumps({'done': True, 'message': {'role': 'assistant', 'content': reply}})}\n\n"
+            except Exception as exc:
+                logger.exception("Interview failed for %s: %s", project_id, exc)
+                yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @app.post("/api/projects/{project_id}/complete")
+    def complete_project_route(project_id: str) -> dict[str, Any]:
+        config = get_config()
+        store = get_store(config)
+        project = store.get_project(project_id)
+        if project is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if not config.llm.api_key:
+            raise HTTPException(status_code=400, detail="Add an LLM API key first.")
+        try:
+            briefing = complete_workspace(
+                config.llm,
+                purpose=project.get("purpose") or "custom",
+                messages=list(project.get("interview_messages") or []),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.exception("Project complete failed: %s", exc)
+            raise HTTPException(status_code=502, detail=f"Could not generate workspace: {exc}") from exc
+
+        updated = store.update_project(
+            project_id,
+            name=briefing["name"],
+            briefing=briefing["briefing"],
+            goals=briefing["goals"],
+            keywords=briefing["keywords"],
+            tone=briefing.get("tone") or "",
+            persona=briefing.get("persona") or "",
+            avoid=briefing.get("avoid") or "",
+            subreddits=briefing.get("subreddits") or [],
+        )
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        config.active_project_id = project_id
+        apply_project_to_config(config, updated)
+        save_config(resolved_path, config)
+        return serialize_project(updated)
+
+    def _merge_links(project: dict[str, Any], researched: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        existing = list(project.get("links") or [])
+        seen = {str(item.get("url") or "") for item in existing}
+        for item in researched:
+            url = str(item.get("url") or "")
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            existing.append(
+                {
+                    "url": url,
+                    "title": item.get("title") or "",
+                    "excerpt": item.get("excerpt") or "",
+                    "ok": bool(item.get("ok")),
+                    "error": item.get("error"),
+                }
+            )
+        return existing
 
     @app.put("/api/secrets")
     def put_secrets(body: SecretsBody) -> dict[str, bool]:

--- a/rcopilot/api.py
+++ b/rcopilot/api.py
@@ -37,6 +37,8 @@ from rcopilot.interview import (
     complete_workspace,
     iter_interview_reply,
     opening_message,
+    split_ready_marker,
+    visible_interview_stream,
 )
 from rcopilot.pipeline import (
     approve_draft,
@@ -882,7 +884,8 @@ def create_app(config_path: str | None = None) -> FastAPI:
         store.update_project(project_id, interview_messages=messages, links=_merge_links(project, researched))
 
         def event_stream() -> Iterator[str]:
-            parts: list[str] = []
+            held = ""
+            emitted = 0
             try:
                 if researched:
                     yield f"data: {json.dumps({'research': researched})}\n\n"
@@ -891,13 +894,16 @@ def create_app(config_path: str | None = None) -> FastAPI:
                     purpose=project.get("purpose") or "custom",
                     messages=messages,
                 ):
-                    parts.append(delta)
-                    yield f"data: {json.dumps({'delta': delta})}\n\n"
-                reply = "".join(parts).strip()
+                    held += delta
+                    visible = visible_interview_stream(held)
+                    if len(visible) > emitted:
+                        yield f"data: {json.dumps({'delta': visible[emitted:]})}\n\n"
+                        emitted = len(visible)
+                reply, ready = split_ready_marker(held)
                 history = list(messages)
                 history.append({"role": "assistant", "content": reply})
                 store.update_project(project_id, interview_messages=history)
-                yield f"data: {json.dumps({'done': True, 'message': {'role': 'assistant', 'content': reply}})}\n\n"
+                yield f"data: {json.dumps({'done': True, 'ready': ready, 'message': {'role': 'assistant', 'content': reply}})}\n\n"
             except Exception as exc:
                 logger.exception("Interview failed for %s: %s", project_id, exc)
                 yield f"data: {json.dumps({'error': str(exc)})}\n\n"

--- a/rcopilot/config.py
+++ b/rcopilot/config.py
@@ -19,6 +19,7 @@ Top comments (for context; do not copy them):
 
 Your background (use only if it genuinely helps answer OP):
 Product/context: {product}
+Goals: {goals}
 Tone: {tone}
 Persona: {persona}
 Things to avoid: {avoid}
@@ -107,6 +108,9 @@ class AppConfig:
     onboarding_step: int = 0
     oauth_redirect_uri: str = "http://127.0.0.1:8000/api/oauth/callback"
     frontend_url: str = "http://localhost:3000"
+    active_project_id: str = ""
+    purpose: str = "product"
+    goals: list[str] = field(default_factory=list)
 
 
 def _env_account_prefix(name: str) -> str:
@@ -126,7 +130,7 @@ def _clamp_onboarding_step(value: Any) -> int:
         step = int(value or 0)
     except (TypeError, ValueError):
         return 0
-    return max(0, min(step, 4))
+    return max(0, min(step, 5))
 
 
 def _fill_account_secrets(account: Account, env: dict[str, str | None]) -> None:
@@ -211,6 +215,9 @@ def load_config(path: str | Path) -> AppConfig:
             raw.get("oauth_redirect_uri") or "http://127.0.0.1:8000/api/oauth/callback"
         ),
         frontend_url=str(raw.get("frontend_url") or "http://localhost:3000"),
+        active_project_id=str(raw.get("active_project_id") or ""),
+        purpose=str(raw.get("purpose") or "product"),
+        goals=[str(item) for item in (raw.get("goals") or []) if str(item).strip()],
     )
 
 
@@ -233,6 +240,7 @@ def _config_to_yaml_dict(config: AppConfig, *, include_secrets: bool = False) ->
         "onboarding_step": config.onboarding_step,
         "oauth_redirect_uri": config.oauth_redirect_uri,
         "frontend_url": config.frontend_url,
+        "active_project_id": config.active_project_id,
     }
 
     for account in config.accounts:
@@ -325,6 +333,9 @@ def sanitize_config(config: AppConfig) -> dict[str, Any]:
     )
     data["has_oauth"] = any(bool(account.refresh_token) for account in config.accounts)
     data["has_api_key"] = bool(config.llm.api_key)
+    data["active_project_id"] = config.active_project_id
+    data["purpose"] = config.purpose or "product"
+    data["goals"] = list(config.goals or [])
     data["accounts"] = [
         {
             "name": account.name,

--- a/rcopilot/interview.py
+++ b/rcopilot/interview.py
@@ -1,0 +1,264 @@
+"""Conversational project briefing (Ollama-safe: no tool calling)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Iterator
+
+from openai import OpenAI
+
+from rcopilot.config import LLMConfig
+from rcopilot.llm import parse_subreddit_list, suggest_subreddits
+from rcopilot.projects import _name_from_briefing
+from rcopilot.research import extract_urls, research_urls
+
+logger = logging.getLogger(__name__)
+
+OPENING_PROMPTS = {
+    "product": (
+        "Tell me about your product. What is it, who is it for, and what problem does it solve? "
+        "You can also paste links to the site, docs, or a launch post."
+    ),
+    "personal": (
+        "Tell me about yourself — what you do, the communities you care about, "
+        "and how you want to show up on Reddit."
+    ),
+    "custom": (
+        "What do you want to do with this copilot? What is your aim — "
+        "the more specific, the better I can set up discovery and drafts."
+    ),
+}
+
+_SYSTEM_BY_PURPOSE = {
+    "product": """You are helping someone set up a Reddit Copilot workspace for a product.
+
+Interview agenda (ask one thing at a time, short messages):
+1. Understand the product (what it is, who it is for, what problem it solves).
+2. Ask what they want out of Reddit (goals: signups, feedback, being helpful in niche subs, etc.).
+3. Invite them to paste links (site, docs, launch post). When page excerpts appear in the thread, use them and ask a follow-up if something important is still missing.
+4. Ask remaining follow-ups: tone, what to avoid, audiences, competitors.
+
+Rules:
+- Sound like a calm desk companion, not a growth hacker.
+- 1–3 short sentences per turn. One question at a time.
+- Never pitch posting automation. This tool only drafts; humans publish.
+- When you have enough to describe the product, goals, and likely Reddit audiences, say you can generate the workspace whenever they are ready.""",
+    "personal": """You are helping someone set up a Reddit Copilot workspace for personal use (not a company product).
+
+Interview agenda (ask one thing at a time, short messages):
+1. Understand them (work, interests, expertise, how they want to sound).
+2. Ask follow-ups until you can picture where they would be a useful commenter.
+3. Ask their Reddit goals (learn, share expertise, job search, hobby community, personal brand — whatever they say).
+4. More follow-ups for tone, topics to avoid, communities they already like.
+
+Rules:
+- Sound like a calm desk companion.
+- 1–3 short sentences per turn. One question at a time.
+- Do not assume they are selling a product.
+- When you have enough, say you can generate the workspace whenever they are ready.""",
+    "custom": """You are helping someone set up a Reddit Copilot workspace with no template.
+
+They will tell you exactly what they want this copilot for. Follow their lead.
+Ask only the follow-ups you need for: who they are in this context, what success looks like, topics/keywords, and which kinds of Reddit communities fit.
+
+Rules:
+- Sound like a calm desk companion.
+- 1–3 short sentences per turn. One question at a time.
+- Do not force a product or personal-brand frame if they described something else.
+- When you have enough, say you can generate the workspace whenever they are ready.""",
+}
+
+EXTRACT_PROMPT = """From this briefing interview, extract a JSON object for a Reddit Copilot workspace.
+
+Purpose: {purpose}
+
+Transcript:
+{transcript}
+
+Return ONLY JSON with keys:
+- name: short workspace name (2–6 words)
+- briefing: 1–3 paragraph summary of who/what this is for (the background used in drafts)
+- goals: array of short goal strings
+- keywords: array of 4–12 discovery keywords/phrases Reddit users might type
+- tone: short tone line
+- persona: short persona notes
+- avoid: things not to say or do in comments
+"""
+
+
+def opening_message(purpose: str) -> dict[str, str]:
+    text = OPENING_PROMPTS.get(purpose) or OPENING_PROMPTS["custom"]
+    return {"role": "assistant", "content": text}
+
+
+def _transcript(messages: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for item in messages:
+        role = item.get("role") or "user"
+        content = (item.get("content") or "").strip()
+        if not content:
+            continue
+        if role == "system":
+            lines.append(f"[context]\n{content}")
+        else:
+            lines.append(f"{role}: {content}")
+    return "\n\n".join(lines)
+
+
+def iter_interview_reply(
+    llm_config: LLMConfig,
+    *,
+    purpose: str,
+    messages: list[dict[str, Any]],
+) -> Iterator[str]:
+    system = _SYSTEM_BY_PURPOSE.get(purpose) or _SYSTEM_BY_PURPOSE["custom"]
+    chat: list[dict[str, str]] = [{"role": "system", "content": system}]
+    for item in messages:
+        role = item.get("role") or "user"
+        content = (item.get("content") or "").strip()
+        if not content:
+            continue
+        if role == "system":
+            chat.append({"role": "system", "content": content})
+        elif role == "assistant":
+            chat.append({"role": "assistant", "content": content})
+        else:
+            chat.append({"role": "user", "content": content})
+
+    client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
+    stream = client.chat.completions.create(
+        model=llm_config.model,
+        messages=chat,
+        temperature=0.7,
+        stream=True,
+    )
+    for chunk in stream:
+        content = chunk.choices[0].delta.content if chunk.choices else None
+        if content:
+            yield content
+
+
+def attach_user_turn(messages: list[dict[str, Any]], text: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Append the user message and any URL research notes. Returns (messages, research results)."""
+    updated = list(messages)
+    updated.append({"role": "user", "content": text.strip()})
+    urls = extract_urls(text)
+    researched = research_urls(urls) if urls else []
+    if researched:
+        bits: list[str] = []
+        for item in researched:
+            if item.get("ok"):
+                bits.append(
+                    f"Fetched {item['url']}\nTitle: {item.get('title') or '(none)'}\n"
+                    f"Excerpt:\n{item.get('excerpt') or ''}"
+                )
+            else:
+                bits.append(f"Could not fetch {item['url']}: {item.get('error')}")
+        updated.append(
+            {
+                "role": "system",
+                "content": "Page research from links the user pasted:\n\n" + "\n\n".join(bits),
+            }
+        )
+    return updated, researched
+
+
+def extract_briefing(
+    llm_config: LLMConfig,
+    *,
+    purpose: str,
+    messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    prompt = EXTRACT_PROMPT.format(purpose=purpose, transcript=_transcript(messages))
+    client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
+    response = client.chat.completions.create(
+        model=llm_config.model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+    raw = response.choices[0].message.content if response.choices else None
+    if not raw or not raw.strip():
+        raise RuntimeError("LLM returned an empty briefing")
+    data = _parse_briefing_json(raw)
+    briefing = str(data.get("briefing") or "").strip()
+    if not briefing:
+        briefing = _fallback_briefing(messages)
+    name = str(data.get("name") or "").strip() or _name_from_briefing(briefing) or "Workspace"
+    goals = _string_list(data.get("goals"))
+    keywords = _string_list(data.get("keywords"))
+    return {
+        "name": name,
+        "briefing": briefing,
+        "goals": goals,
+        "keywords": keywords,
+        "tone": str(data.get("tone") or "").strip(),
+        "persona": str(data.get("persona") or "").strip(),
+        "avoid": str(data.get("avoid") or "").strip(),
+    }
+
+
+def complete_workspace(
+    llm_config: LLMConfig,
+    *,
+    purpose: str,
+    messages: list[dict[str, Any]],
+    count: int = 12,
+) -> dict[str, Any]:
+    briefing = extract_briefing(llm_config, purpose=purpose, messages=messages)
+    goals_text = "; ".join(briefing["goals"])
+    try:
+        subreddits = suggest_subreddits(
+            llm_config,
+            product=briefing["briefing"],
+            tone=briefing.get("tone") or "",
+            persona=briefing.get("persona") or "",
+            count=count,
+            purpose=purpose,
+            goals=briefing.get("goals") or [],
+        )
+    except Exception:
+        logger.exception("subreddit suggestion during interview complete failed")
+        subreddits = []
+    briefing["subreddits"] = subreddits
+    briefing["goals_text"] = goals_text
+    return briefing
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        items = [part.strip() for part in re.split(r"[\n,]", value) if part.strip()]
+        return items
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        text = str(item).strip()
+        if text:
+            result.append(text)
+    return result
+
+
+def _parse_briefing_json(raw: str) -> dict[str, Any]:
+    text = raw.strip()
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+    if fence:
+        text = fence.group(1)
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("LLM did not return a briefing object")
+    data = json.loads(text[start : end + 1])
+    if not isinstance(data, dict):
+        raise ValueError("LLM briefing payload was not an object")
+    return data
+
+
+def _fallback_briefing(messages: list[dict[str, Any]]) -> str:
+    user_bits = [
+        str(item.get("content") or "").strip()
+        for item in messages
+        if item.get("role") == "user" and str(item.get("content") or "").strip()
+    ]
+    return "\n\n".join(user_bits)[:2000]

--- a/rcopilot/interview.py
+++ b/rcopilot/interview.py
@@ -31,8 +31,17 @@ OPENING_PROMPTS = {
     ),
 }
 
+READY_MARKER = "READY_FOR_WORKSPACE"
+
+_READY_RULE = (
+    "When you have enough to generate the workspace — a name, a short briefing, "
+    "and at least one goal — do not ask another question. Write one short sentence "
+    f"that you are setting up the workspace now, then on its own last line write exactly: {READY_MARKER}\n"
+    f"If anything important is still missing, ask one question and do not write {READY_MARKER}."
+)
+
 _SYSTEM_BY_PURPOSE = {
-    "product": """You are helping someone set up a Reddit Copilot workspace for a product.
+    "product": f"""You are helping someone set up a Reddit Copilot workspace for a product.
 
 Interview agenda (ask one thing at a time, short messages):
 1. Understand the product (what it is, who it is for, what problem it solves).
@@ -44,8 +53,8 @@ Rules:
 - Sound like a calm desk companion, not a growth hacker.
 - 1–3 short sentences per turn. One question at a time.
 - Never pitch posting automation. This tool only drafts; humans publish.
-- When you have enough to describe the product, goals, and likely Reddit audiences, say you can generate the workspace whenever they are ready.""",
-    "personal": """You are helping someone set up a Reddit Copilot workspace for personal use (not a company product).
+- {_READY_RULE}""",
+    "personal": f"""You are helping someone set up a Reddit Copilot workspace for personal use (not a company product).
 
 Interview agenda (ask one thing at a time, short messages):
 1. Understand them (work, interests, expertise, how they want to sound).
@@ -57,8 +66,8 @@ Rules:
 - Sound like a calm desk companion.
 - 1–3 short sentences per turn. One question at a time.
 - Do not assume they are selling a product.
-- When you have enough, say you can generate the workspace whenever they are ready.""",
-    "custom": """You are helping someone set up a Reddit Copilot workspace with no template.
+- {_READY_RULE}""",
+    "custom": f"""You are helping someone set up a Reddit Copilot workspace with no template.
 
 They will tell you exactly what they want this copilot for. Follow their lead.
 Ask only the follow-ups you need for: who they are in this context, what success looks like, topics/keywords, and which kinds of Reddit communities fit.
@@ -67,7 +76,7 @@ Rules:
 - Sound like a calm desk companion.
 - 1–3 short sentences per turn. One question at a time.
 - Do not force a product or personal-brand frame if they described something else.
-- When you have enough, say you can generate the workspace whenever they are ready.""",
+- {_READY_RULE}""",
 }
 
 EXTRACT_PROMPT = """From this briefing interview, extract a JSON object for a Reddit Copilot workspace.
@@ -86,6 +95,35 @@ Return ONLY JSON with keys:
 - persona: short persona notes
 - avoid: things not to say or do in comments
 """
+
+
+def split_ready_marker(text: str) -> tuple[str, bool]:
+    """Strip the end-of-interview marker. Returns (visible text, ready)."""
+    if not (text or "").strip():
+        return (text or "").rstrip(), False
+    stripped = text.rstrip()
+    lines = stripped.splitlines()
+    if lines and lines[-1].strip() == READY_MARKER:
+        body = "\n".join(lines[:-1]).rstrip()
+        return body, True
+    if READY_MARKER in stripped:
+        return stripped.replace(READY_MARKER, "").rstrip(), True
+    return stripped, False
+
+
+def visible_interview_stream(buffer: str) -> str:
+    """Hide a trailing READY_FOR_WORKSPACE (including a partial last line) while streaming."""
+    visible, ready = split_ready_marker(buffer)
+    if ready:
+        return visible
+    if "\n" in buffer:
+        head, last = buffer.rsplit("\n", 1)
+        if last and READY_MARKER.startswith(last):
+            return head
+        return buffer
+    if buffer and READY_MARKER.startswith(buffer) and len(buffer) >= 4:
+        return ""
+    return buffer
 
 
 def opening_message(purpose: str) -> dict[str, str]:

--- a/rcopilot/llm.py
+++ b/rcopilot/llm.py
@@ -46,6 +46,7 @@ def _build_comment_prompt(
     tone: str = "",
     persona: str = "",
     avoid: str = "",
+    goals: str = "",
 ) -> str:
     return prompt_template.format_map(
         SafeDict(
@@ -56,6 +57,7 @@ def _build_comment_prompt(
             tone=tone,
             persona=persona,
             avoid=avoid,
+            goals=goals,
         )
     )
 
@@ -71,6 +73,7 @@ def iter_comment_deltas(
     tone: str = "",
     persona: str = "",
     avoid: str = "",
+    goals: str = "",
 ) -> Iterator[str]:
     """Stream raw comment text deltas from an OpenAI-compatible chat completion API."""
     prompt = _build_comment_prompt(
@@ -82,6 +85,7 @@ def iter_comment_deltas(
         tone=tone,
         persona=persona,
         avoid=avoid,
+        goals=goals,
     )
 
     client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
@@ -130,6 +134,7 @@ def generate_comment(
     tone: str = "",
     persona: str = "",
     avoid: str = "",
+    goals: str = "",
 ) -> str:
     """Generate a Reddit comment using an OpenAI-compatible chat completion API."""
     prompt = _build_comment_prompt(
@@ -141,6 +146,7 @@ def generate_comment(
         tone=tone,
         persona=persona,
         avoid=avoid,
+        goals=goals,
     )
 
     client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
@@ -222,6 +228,7 @@ SUBMISSION_PROMPT = """Write an original Reddit self-post for r/{subreddit}.
 
 Your background (use lightly — this is not a pitch post):
 Product/context: {product}
+Goals: {goals}
 Tone: {tone}
 Persona: {persona}
 Things to avoid: {avoid}
@@ -270,6 +277,7 @@ def generate_submission(
     tone: str = "",
     persona: str = "",
     avoid: str = "",
+    goals: str = "",
 ) -> tuple[str, str]:
     """Generate an original self-post title and body for a subreddit."""
     cleaned = subreddit.strip().lstrip("r/")
@@ -280,6 +288,7 @@ def generate_submission(
             tone=tone or "(none)",
             persona=persona or "(none)",
             avoid=avoid or "(none)",
+            goals=goals or "(none)",
         )
     )
     client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
@@ -333,15 +342,32 @@ def suggest_subreddits(
     tone: str = "",
     persona: str = "",
     count: int = 12,
+    purpose: str = "product",
+    goals: list[str] | None = None,
 ) -> list[str]:
-    """Suggest relevant subreddits from product voice context."""
+    """Suggest relevant subreddits from workspace briefing context."""
     if not (product or "").strip():
-        raise ValueError("Describe your product before suggesting subreddits")
+        raise ValueError("Add a briefing before suggesting subreddits")
     n = max(4, min(int(count), 20))
-    prompt = f"""Suggest Reddit communities where someone with this product should participate.
+    goals_text = ", ".join(goals or []) or "(not specified)"
+    if purpose == "personal":
+        frame = "a person participating as themselves"
+        mix = "hobby, career, local, and interest communities where a helpful human comment belongs"
+    elif purpose == "custom":
+        frame = "this custom aim"
+        mix = "communities where that aim is a natural fit — not spammy promo subs"
+    else:
+        frame = "someone with this product"
+        mix = "discussion communities, founder/product audiences, problem-space niches"
+    prompt = f"""Suggest Reddit communities where {frame} should participate.
 
-Product / what they make:
+Purpose: {purpose}
+
+Background / briefing:
 {product.strip()}
+
+Goals:
+{goals_text}
 
 Tone:
 {tone.strip() or "(not specified)"}
@@ -349,7 +375,7 @@ Tone:
 Persona:
 {persona.strip() or "(not specified)"}
 
-Return {n} real, active subreddit names that fit (discussion communities, founder/product audiences, problem-space niches). Mix broad and niche. Prefer communities where helpful comments or organic self-posts make sense — not spammy promo subs.
+Return {n} real, active subreddit names that fit ({mix}). Mix broad and niche. Prefer communities where helpful comments or organic self-posts make sense — not spammy promo subs.
 
 Rules:
 - Names only, no r/ prefix
@@ -370,19 +396,40 @@ Rules:
     return parse_subreddit_list(content, limit=n)
 
 
-def generate_search_queries(
-    llm_config: LLMConfig,
+def build_search_query_prompt(
     *,
     product: str,
     keywords: list[str],
     subreddits: list[str],
     persona: str = "",
-) -> list[str]:
-    """Ask the LLM for varied Reddit search queries, then fall back locally if needed."""
-    prompt = f"""Generate Reddit search queries to find threads where someone might need this product.
+    purpose: str = "product",
+    goals: list[str] | None = None,
+) -> str:
+    goals_text = ", ".join(goals or []) or "(none)"
+    if purpose == "product":
+        intent = (
+            "find threads where someone might need this product or be asking about the problem it solves.\n"
+            "Mix: looking for / recommend / anyone using, alternative to, problem statements, how do you / what do you use."
+        )
+    elif purpose == "personal":
+        intent = (
+            "find threads where this person can be useful, given their goals — not buying-intent product hunt queries unless that is the goal.\n"
+            "Mix: questions in their domain, advice requests, experiences, how do you / what do you use."
+        )
+    else:
+        intent = (
+            "find threads that match this custom aim and stated goals.\n"
+            "Mix: the language real Reddit users would type for that aim."
+        )
+    return f"""Generate Reddit search queries to {intent}
 
-Product:
+Purpose: {purpose}
+
+Background:
 {product or "(not described)"}
+
+Goals:
+{goals_text}
 
 Persona notes:
 {persona or "(none)"}
@@ -393,14 +440,30 @@ Keywords they already care about:
 They watch these subreddits (do not put subreddit names in the queries):
 {", ".join(subreddits) if subreddits else "(none)"}
 
-Write {QUERY_LIMIT} short queries a real Reddit user might type. Mix:
-- looking for / recommend / anyone using
-- alternative to
-- problem statements
-- how do you / what do you use
-
+Write {QUERY_LIMIT} short queries a real Reddit user might type.
 No site operators, no subreddit names, no quotes around the whole list.
 Return ONLY a JSON array of strings."""
+
+
+def generate_search_queries(
+    llm_config: LLMConfig,
+    *,
+    product: str,
+    keywords: list[str],
+    subreddits: list[str],
+    persona: str = "",
+    purpose: str = "product",
+    goals: list[str] | None = None,
+) -> list[str]:
+    """Ask the LLM for varied Reddit search queries, then fall back locally if needed."""
+    prompt = build_search_query_prompt(
+        product=product,
+        keywords=keywords,
+        subreddits=subreddits,
+        persona=persona,
+        purpose=purpose,
+        goals=goals,
+    )
 
     client = OpenAI(base_url=llm_config.base_url, api_key=llm_config.api_key)
     logger.info("Generating discovery search queries with model %s", llm_config.model)

--- a/rcopilot/pipeline.py
+++ b/rcopilot/pipeline.py
@@ -19,8 +19,9 @@ from rcopilot.llm import (
     generate_submission,
     iter_comment_deltas,
 )
+from rcopilot.projects import persist_queries_to_project
 from rcopilot.scoring import apply_scores
-from rcopilot.store import Store
+from rcopilot.store import DEFAULT_PROJECT_ID, Store
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +37,17 @@ def _resolve_account(config: AppConfig, account_name: str | None) -> Account:
     return config.accounts[0]
 
 
+def _project_id(config: AppConfig) -> str:
+    return (config.active_project_id or "").strip() or DEFAULT_PROJECT_ID
+
+
 def _voice_kwargs(config: AppConfig) -> dict[str, str]:
     return {
         "product": config.voice.product,
         "tone": config.voice.tone,
         "persona": config.voice.persona,
         "avoid": config.voice.avoid,
+        "goals": "; ".join(config.goals) if config.goals else "",
     }
 
 
@@ -51,6 +57,8 @@ def _queries_fingerprint(config: AppConfig) -> str:
         "persona": config.voice.persona,
         "keywords": config.discovery.keywords,
         "subreddits": config.subreddits,
+        "purpose": config.purpose,
+        "goals": config.goals,
     }
     encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()[:16]
@@ -76,6 +84,8 @@ def ensure_search_queries(
                 keywords=config.discovery.keywords,
                 subreddits=config.subreddits,
                 persona=config.voice.persona,
+                purpose=config.purpose,
+                goals=config.goals,
             )
         except Exception:
             logger.exception("LLM search-query generation failed; using fallback queries")
@@ -109,12 +119,12 @@ def fetch_and_store(
     if not account.refresh_token and not (account.username and account.password):
         raise ValueError("Reddit is not connected. Use Connect Reddit in onboarding or Settings.")
     reddit = reddit_client.get_reddit(account)
+    project_id = _project_id(config)
 
-    existing_ids = {
-        row["id"] for row in store.connect().execute("SELECT id FROM posts").fetchall()
-    }
+    existing_ids = store.list_post_ids(project_id=project_id)
 
     queries = ensure_search_queries(config, config_path=config_path)
+    persist_queries_to_project(store, config)
     fetched = reddit_client.fetch_posts(
         reddit,
         config.subreddits,
@@ -141,15 +151,22 @@ def fetch_and_store(
     stored_posts: list[dict[str, Any]] = []
     for post in merged:
         is_new = post["id"] not in existing_ids
-        store.upsert_post(**post)
-        stored_posts.append(store.get_post(post["id"]) or post)
+        store.upsert_post(**post, project_id=project_id)
+        stored_posts.append(store.get_post(post["id"], project_id=project_id) or post)
         if is_new:
             existing_ids.add(post["id"])
             new_count += 1
 
-    apply_scores(store, stored_posts, config.discovery, product=config.voice.product)
+    apply_scores(
+        store,
+        stored_posts,
+        config.discovery,
+        product=config.voice.product,
+        project_id=project_id,
+    )
     store.add_audit(
         "fetched",
+        project_id=project_id,
         detail={
             "new_count": new_count,
             "total": len(stored_posts),
@@ -179,7 +196,12 @@ def _generate_draft_body(config: AppConfig, post: dict[str, Any]) -> str:
 
 
 def _eligible_posts_for_drafting(store: Store, config: AppConfig) -> list[dict[str, Any]]:
-    posts = store.list_posts(undrafted=True, skipped=False, min_score=config.discovery.min_score)
+    posts = store.list_posts(
+        project_id=_project_id(config),
+        undrafted=True,
+        skipped=False,
+        min_score=config.discovery.min_score,
+    )
     return posts
 
 
@@ -195,15 +217,25 @@ def draft_pending(config: AppConfig, store: Store, account_name: str | None = No
     for post in posts:
         try:
             body = _generate_draft_body(config, post)
-            draft_id = store.create_draft(post["id"], account.name, body, status="pending")
-            store.add_audit("drafted", draft_id=draft_id, post_id=post["id"])
+            draft_id = store.create_draft(
+                post["id"], account.name, body, status="pending", project_id=_project_id(config)
+            )
+            store.add_audit("drafted", draft_id=draft_id, post_id=post["id"], project_id=_project_id(config))
             created += 1
             logger.info("Drafted comment for post %s", post["id"])
         except Exception as exc:
             logger.exception("LLM draft failed for post %s: %s", post["id"], exc)
-            draft_id = store.create_draft(post["id"], account.name, "", status="error")
+            draft_id = store.create_draft(
+                post["id"], account.name, "", status="error", project_id=_project_id(config)
+            )
             store.update_draft(draft_id, error=str(exc))
-            store.add_audit("draft_error", draft_id=draft_id, post_id=post["id"], detail={"error": str(exc)})
+            store.add_audit(
+                "draft_error",
+                draft_id=draft_id,
+                post_id=post["id"],
+                project_id=_project_id(config),
+                detail={"error": str(exc)},
+            )
 
     logger.info("Created %d draft(s)", created)
     return created
@@ -212,15 +244,13 @@ def draft_pending(config: AppConfig, store: Store, account_name: str | None = No
 def draft_one(config: AppConfig, store: Store, post_id: str, account_name: str | None = None) -> int:
     """Generate an LLM draft for a single post (CLI / legacy). Prefer queue_post + stream in the UI."""
     store.ensure_schema()
-    post = store.get_post(post_id)
+    project_id = _project_id(config)
+    post = store.get_post(post_id, project_id=project_id)
     if post is None:
         raise ValueError(f"Post not found: {post_id}")
     if post.get("skipped"):
         raise ValueError(f"Post {post_id} is skipped")
-    existing = store.connect().execute(
-        "SELECT id FROM drafts WHERE post_id = ?", (post_id,)
-    ).fetchone()
-    if existing:
+    if store.draft_exists_for_post(post_id, project_id=project_id):
         raise ValueError(f"Post {post_id} already has a draft")
 
     account = _resolve_account(config, account_name)
@@ -229,33 +259,37 @@ def draft_one(config: AppConfig, store: Store, post_id: str, account_name: str |
 
     try:
         body = _generate_draft_body(config, post)
-        draft_id = store.create_draft(post_id, account.name, body, status="pending")
-        store.add_audit("drafted", draft_id=draft_id, post_id=post_id)
+        draft_id = store.create_draft(post_id, account.name, body, status="pending", project_id=project_id)
+        store.add_audit("drafted", draft_id=draft_id, post_id=post_id, project_id=project_id)
         return draft_id
     except Exception as exc:
-        draft_id = store.create_draft(post_id, account.name, "", status="error")
+        draft_id = store.create_draft(post_id, account.name, "", status="error", project_id=project_id)
         store.update_draft(draft_id, error=str(exc))
-        store.add_audit("draft_error", draft_id=draft_id, post_id=post_id, detail={"error": str(exc)})
+        store.add_audit(
+            "draft_error",
+            draft_id=draft_id,
+            post_id=post_id,
+            project_id=project_id,
+            detail={"error": str(exc)},
+        )
         raise
 
 
 def queue_post(config: AppConfig, store: Store, post_id: str, account_name: str | None = None) -> int:
     """Add a post to the review queue without generating a reply yet."""
     store.ensure_schema()
-    post = store.get_post(post_id)
+    project_id = _project_id(config)
+    post = store.get_post(post_id, project_id=project_id)
     if post is None:
         raise ValueError(f"Post not found: {post_id}")
     if post.get("skipped"):
         raise ValueError(f"Post {post_id} is skipped")
-    existing = store.connect().execute(
-        "SELECT id FROM drafts WHERE post_id = ?", (post_id,)
-    ).fetchone()
-    if existing:
+    if store.draft_exists_for_post(post_id, project_id=project_id):
         raise ValueError(f"Post {post_id} is already in the review queue")
 
     account = _resolve_account(config, account_name)
-    draft_id = store.create_draft(post_id, account.name, "", status="pending")
-    store.add_audit("queued", draft_id=draft_id, post_id=post_id)
+    draft_id = store.create_draft(post_id, account.name, "", status="pending", project_id=project_id)
+    store.add_audit("queued", draft_id=draft_id, post_id=post_id, project_id=project_id)
     logger.info("Queued post %s as draft %d", post_id, draft_id)
     return draft_id
 
@@ -302,13 +336,13 @@ def finish_draft_stream(
     return body
 
 
-def skip_post(store: Store, post_id: str) -> None:
+def skip_post(store: Store, post_id: str, *, project_id: str = DEFAULT_PROJECT_ID) -> None:
     """Mark a post as skipped."""
-    post = store.get_post(post_id)
+    post = store.get_post(post_id, project_id=project_id)
     if post is None:
         raise ValueError(f"Post not found: {post_id}")
-    store.update_post(post_id, skipped=1)
-    store.add_audit("skipped", post_id=post_id)
+    store.update_post(post_id, project_id=project_id, skipped=1)
+    store.add_audit("skipped", post_id=post_id, project_id=project_id)
 
 
 def regenerate_draft(config: AppConfig, store: Store, draft_id: int) -> None:
@@ -397,10 +431,12 @@ def create_submission_draft(
         subreddit=cleaned_sub,
         title=cleaned_title,
         body=cleaned_body,
+        project_id=_project_id(config),
     )
     store.add_audit(
         "submission_created",
         draft_id=draft_id,
+        project_id=_project_id(config),
         detail={"subreddit": cleaned_sub, "title": cleaned_title},
     )
     return draft_id
@@ -440,10 +476,12 @@ def generate_submission_ideas(
                 subreddit=subreddit,
                 title=title,
                 body=body,
+                project_id=_project_id(config),
             )
             store.add_audit(
                 "submission_generated",
                 draft_id=draft_id,
+                project_id=_project_id(config),
                 detail={"subreddit": subreddit, "title": title},
             )
             created_ids.append(draft_id)
@@ -743,8 +781,33 @@ def run_once(
     config_path: str | Path | None = None,
 ) -> dict[str, int]:
     """Run one worker cycle: fetch, draft eligible posts, post due schedules, poll outcomes."""
-    fetched = fetch_and_store(config, store, config_path=config_path)
-    drafted = draft_pending(config, store)
+    from rcopilot.projects import apply_project_to_config, seed_projects_from_config
+
+    store.ensure_schema()
+    seed_projects_from_config(store, config)
+    original_id = _project_id(config)
+    projects = [item for item in store.list_projects() if item.get("subreddits")]
+    fetched = 0
+    drafted = 0
+    if projects:
+        for project in projects:
+            apply_project_to_config(config, project)
+            try:
+                fetched += fetch_and_store(config, store, config_path=config_path)
+            except ValueError as exc:
+                logger.warning("Fetch skipped for project %s: %s", project.get("id"), exc)
+            try:
+                drafted += draft_pending(config, store)
+            except ValueError as exc:
+                logger.warning("Draft skipped for project %s: %s", project.get("id"), exc)
+        original = store.get_project(original_id)
+        if original:
+            apply_project_to_config(config, original)
+            if config_path:
+                save_config(config_path, config)
+    else:
+        fetched = fetch_and_store(config, store, config_path=config_path)
+        drafted = draft_pending(config, store)
     scheduled_results = post_due_scheduled(config, store)
     posted = sum(1 for item in scheduled_results if item.get("ok"))
     outcomes = poll_outcomes(config, store)
@@ -758,6 +821,13 @@ def run_once(
 
 def rescore_posts(store: Store, config: AppConfig) -> int:
     """Re-score all posts (useful after config keyword changes)."""
-    posts = store.list_posts()
-    apply_scores(store, posts, config.discovery, product=config.voice.product)
+    project_id = _project_id(config)
+    posts = store.list_posts(project_id=project_id)
+    apply_scores(
+        store,
+        posts,
+        config.discovery,
+        product=config.voice.product,
+        project_id=project_id,
+    )
     return len(posts)

--- a/rcopilot/projects.py
+++ b/rcopilot/projects.py
@@ -143,6 +143,7 @@ def serialize_project(project: dict[str, Any]) -> dict[str, Any]:
         "keywords": list(project.get("keywords") or []),
         "search_queries": list(project.get("search_queries") or []),
         "complete": bool(project.get("complete")),
+        "setup_step": int(project.get("setup_step") or 0),
         "created_at": project.get("created_at"),
         "updated_at": project.get("updated_at"),
     }

--- a/rcopilot/projects.py
+++ b/rcopilot/projects.py
@@ -1,0 +1,168 @@
+"""Project workspaces: seed, hydrate, and mirror into AppConfig."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rcopilot.config import AppConfig, DiscoveryConfig, VoiceConfig
+from rcopilot.store import DEFAULT_PROJECT_ID, Store
+
+
+def project_is_complete(project: dict[str, Any] | None) -> bool:
+    if not project:
+        return False
+    if project.get("complete"):
+        return True
+    return bool(project.get("subreddits")) and bool((project.get("briefing") or "").strip())
+
+
+def has_finished_project(store: Store) -> bool:
+    return any(project_is_complete(item) for item in store.list_projects(include_empty=True))
+
+
+def seed_projects_from_config(store: Store, config: AppConfig) -> dict[str, Any] | None:
+    """If yaml still holds the only voice/subreddits, copy them onto the default project."""
+    store.ensure_schema()
+    visible = store.list_projects()
+    if visible:
+        return None
+
+    default = store.get_project(DEFAULT_PROJECT_ID)
+    has_legacy = bool(
+        (config.voice.product or "").strip()
+        or config.onboarding_complete
+    )
+    if not has_legacy or default is None:
+        return None
+
+    name = _name_from_briefing(config.voice.product) or "Default"
+    return store.update_project(
+        DEFAULT_PROJECT_ID,
+        name=name,
+        purpose="product",
+        briefing=config.voice.product,
+        tone=config.voice.tone,
+        persona=config.voice.persona,
+        avoid=config.voice.avoid,
+        subreddits=list(config.subreddits),
+        keywords=list(config.discovery.keywords),
+        search_queries=list(config.discovery.search_queries),
+        queries_fingerprint=config.discovery.queries_fingerprint,
+        complete=bool(config.onboarding_complete and config.subreddits),
+    )
+
+
+def resolve_active_project(store: Store, config: AppConfig) -> dict[str, Any] | None:
+    seed_projects_from_config(store, config)
+    wanted = (config.active_project_id or "").strip()
+    if wanted:
+        project = store.get_project(wanted)
+        if project:
+            return project
+    visible = store.list_projects()
+    if visible:
+        return visible[0]
+    return store.get_project(DEFAULT_PROJECT_ID)
+
+
+def apply_project_to_config(config: AppConfig, project: dict[str, Any] | None) -> AppConfig:
+    """Copy project briefing/subs into the in-memory config used by pipeline + API."""
+    if not project:
+        return config
+    config.active_project_id = project["id"]
+    unused = not (
+        project.get("complete")
+        or (project.get("briefing") or "").strip()
+        or project.get("subreddits")
+    )
+    if unused:
+        return config
+    config.purpose = project.get("purpose") or "product"
+    config.goals = list(project.get("goals") or [])
+    config.voice = VoiceConfig(
+        product=project.get("briefing") or "",
+        tone=project.get("tone") or "",
+        persona=project.get("persona") or "",
+        avoid=project.get("avoid") or "",
+    )
+    config.subreddits = list(project.get("subreddits") or [])
+    config.discovery = DiscoveryConfig(
+        keywords=list(project.get("keywords") or []),
+        min_score=config.discovery.min_score,
+        search_queries=list(project.get("search_queries") or []),
+        queries_fingerprint=str(project.get("queries_fingerprint") or ""),
+    )
+    return config
+
+
+def persist_config_to_project(store: Store, config: AppConfig) -> dict[str, Any] | None:
+    """Write voice/subreddits/keywords from config onto the active project."""
+    project_id = (config.active_project_id or "").strip() or DEFAULT_PROJECT_ID
+    project = store.get_project(project_id)
+    if project is None:
+        return None
+    return store.update_project(
+        project_id,
+        briefing=config.voice.product,
+        tone=config.voice.tone,
+        persona=config.voice.persona,
+        avoid=config.voice.avoid,
+        purpose=config.purpose if config.purpose in ("product", "personal", "custom") else project["purpose"],
+        subreddits=list(config.subreddits),
+        keywords=list(config.discovery.keywords),
+        search_queries=list(config.discovery.search_queries),
+        queries_fingerprint=config.discovery.queries_fingerprint,
+        goals=list(config.goals or []),
+    )
+
+
+def persist_queries_to_project(store: Store, config: AppConfig) -> None:
+    project_id = (config.active_project_id or "").strip() or DEFAULT_PROJECT_ID
+    if store.get_project(project_id) is None:
+        return
+    store.update_project(
+        project_id,
+        search_queries=list(config.discovery.search_queries),
+        queries_fingerprint=config.discovery.queries_fingerprint,
+    )
+
+
+def serialize_project(project: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": project["id"],
+        "name": project.get("name") or "",
+        "purpose": project.get("purpose") or "product",
+        "briefing": project.get("briefing") or "",
+        "goals": list(project.get("goals") or []),
+        "links": list(project.get("links") or []),
+        "interview_messages": list(project.get("interview_messages") or []),
+        "tone": project.get("tone") or "",
+        "persona": project.get("persona") or "",
+        "avoid": project.get("avoid") or "",
+        "subreddits": list(project.get("subreddits") or []),
+        "keywords": list(project.get("keywords") or []),
+        "search_queries": list(project.get("search_queries") or []),
+        "complete": bool(project.get("complete")),
+        "created_at": project.get("created_at"),
+        "updated_at": project.get("updated_at"),
+    }
+
+
+def serialize_project_summary(project: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": project["id"],
+        "name": project.get("name") or _name_from_briefing(project.get("briefing") or "") or "Untitled",
+        "purpose": project.get("purpose") or "product",
+        "complete": bool(project.get("complete")),
+    }
+
+
+def _name_from_briefing(briefing: str) -> str:
+    text = (briefing or "").strip()
+    if not text:
+        return ""
+    first = text.splitlines()[0].strip()
+    first = first.split(".")[0].strip()
+    if len(first) > 48:
+        first = first[:45].rstrip() + "…"
+    return first

--- a/rcopilot/research.py
+++ b/rcopilot/research.py
@@ -1,0 +1,89 @@
+"""Fetch user-pasted URLs for project briefing (not Reddit scraping)."""
+
+from __future__ import annotations
+
+import re
+import html as html_lib
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+_URL_RE = re.compile(r"https?://[^\s<>\"')\]]+", re.IGNORECASE)
+_TAG_RE = re.compile(r"<script[\s\S]*?</script>|<style[\s\S]*?</style>|<[^>]+>", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+MAX_CHARS = 4000
+FETCH_TIMEOUT = 8
+USER_AGENT = "RedditCopilot/1.0 (workspace briefing; user-pasted URL)"
+
+
+def extract_urls(text: str) -> list[str]:
+    found: list[str] = []
+    seen: set[str] = set()
+    for match in _URL_RE.findall(text or ""):
+        cleaned = match.rstrip(".,;:!?")
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        if _is_reddit_url(cleaned):
+            continue
+        seen.add(key)
+        found.append(cleaned)
+    return found
+
+
+def _is_reddit_url(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host == "reddit.com" or host.endswith(".reddit.com") or host == "redd.it"
+
+
+def fetch_url_excerpt(url: str, *, max_chars: int = MAX_CHARS) -> dict[str, Any]:
+    """Download a user-pasted page and return title + plain-text excerpt."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return {"url": url, "ok": False, "error": "Only http(s) links can be read."}
+    if _is_reddit_url(url):
+        return {"url": url, "ok": False, "error": "Reddit links are read via the Reddit API, not fetched."}
+
+    request = Request(url, headers={"User-Agent": USER_AGENT, "Accept": "text/html,text/plain"})
+    try:
+        with urlopen(request, timeout=FETCH_TIMEOUT) as response:
+            raw = response.read(200_000)
+            charset = response.headers.get_content_charset() or "utf-8"
+    except HTTPError as exc:
+        return {"url": url, "ok": False, "error": f"Could not read that page ({exc.code})."}
+    except URLError as exc:
+        return {"url": url, "ok": False, "error": f"Could not reach that page ({exc.reason})."}
+    except TimeoutError:
+        return {"url": url, "ok": False, "error": "That page took too long to respond."}
+    except Exception as exc:  # noqa: BLE001
+        return {"url": url, "ok": False, "error": str(exc)}
+
+    try:
+        html = raw.decode(charset, errors="replace")
+    except LookupError:
+        html = raw.decode("utf-8", errors="replace")
+
+    title_match = _TITLE_RE.search(html)
+    title = html_lib.unescape(_WHITESPACE_RE.sub(" ", title_match.group(1))).strip() if title_match else ""
+    text = _TAG_RE.sub(" ", html)
+    text = html_lib.unescape(text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if len(text) > max_chars:
+        text = text[: max_chars - 1].rstrip() + "…"
+    return {
+        "url": url,
+        "ok": True,
+        "title": title or parsed.netloc,
+        "excerpt": text,
+        "error": None,
+    }
+
+
+def research_urls(urls: list[str]) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for url in urls[:5]:
+        results.append(fetch_url_excerpt(url))
+    return results

--- a/rcopilot/scoring.py
+++ b/rcopilot/scoring.py
@@ -217,11 +217,11 @@ def classify_intent(post: dict[str, Any]) -> list[str]:
     return labels
 
 
-def intent_terms_from_product(product: str, *, limit: int = 12) -> list[str]:
-    """Turn a product blurb into short phrases/tokens to match against threads."""
+def intent_terms_from_briefing(briefing: str, *, limit: int = 12) -> list[str]:
+    """Turn a workspace briefing into short phrases/tokens to match against threads."""
     tokens = [
         token
-        for token in _TOKEN.findall(product.lower())
+        for token in _TOKEN.findall(briefing.lower())
         if len(token) >= 4 and token not in _STOPWORDS and token not in _GENERIC
     ]
     terms: list[str] = []
@@ -236,6 +236,11 @@ def intent_terms_from_product(product: str, *, limit: int = 12) -> list[str]:
             seen.add(token)
             terms.append(token)
     return terms[:limit]
+
+
+def intent_terms_from_product(product: str, *, limit: int = 12) -> list[str]:
+    """Alias for briefing terms (legacy name)."""
+    return intent_terms_from_briefing(product, limit=limit)
 
 
 def score_post(
@@ -275,17 +280,17 @@ def score_post(
             score += keyword_score
             reasons.append(f"keyword match (+{keyword_score:.2f})")
 
-    product_terms = intent_terms_from_product(product)
-    if product_terms:
-        product_score = 0.0
-        for term in product_terms:
+    briefing_terms = intent_terms_from_briefing(product)
+    if briefing_terms:
+        briefing_score = 0.0
+        for term in briefing_terms:
             if term in text:
                 matched.append(term)
-                product_score += 0.12
-        product_score = min(product_score, 0.36)
-        if product_score:
-            score += product_score
-            reasons.append(f"product match (+{product_score:.2f})")
+                briefing_score += 0.12
+        briefing_score = min(briefing_score, 0.36)
+        if briefing_score:
+            score += briefing_score
+            reasons.append(f"context match (+{briefing_score:.2f})")
 
     if "looking-for-tool" in labels:
         score += 0.2
@@ -314,7 +319,7 @@ def score_post(
             score += 0.05
             reasons.append("recent (<24h) (+0.05)")
 
-    if (keywords or product_terms) and not matched:
+    if (keywords or briefing_terms) and not matched:
         score = min(score, 0.2)
         reasons.append("weak intent fit (capped)")
 
@@ -326,14 +331,20 @@ def apply_scores(
     posts: list[dict[str, Any]],
     discovery: DiscoveryConfig,
     product: str = "",
+    *,
+    project_id: str | None = None,
 ) -> None:
     """Compute and persist scores for *posts*."""
+    from rcopilot.store import DEFAULT_PROJECT_ID
+
+    scoped_id = project_id or DEFAULT_PROJECT_ID
     for post in posts:
         score, reasons, matched, labels = score_post(
             post, discovery.keywords, product=product
         )
         store.update_post(
             post["id"],
+            project_id=scoped_id,
             relevance_score=score,
             score_reasons=json.dumps(reasons),
             keywords_matched=json.dumps(matched),

--- a/rcopilot/store.py
+++ b/rcopilot/store.py
@@ -173,6 +173,7 @@ class Store:
         self._add_column_if_missing(conn, "drafts", "submission_id", "TEXT")
         self._add_column_if_missing(conn, "drafts", "project_id", "TEXT NOT NULL DEFAULT 'default'")
         self._add_column_if_missing(conn, "audit_events", "project_id", "TEXT")
+        self._add_column_if_missing(conn, "projects", "setup_step", "INTEGER NOT NULL DEFAULT 0")
         self._migrate_drafts_nullable_post_id(conn)
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_drafts_project ON drafts(project_id, status)"
@@ -893,6 +894,17 @@ class Store:
             raise RuntimeError("Failed to create project")
         return project
 
+    def find_setup_project(self) -> dict[str, Any] | None:
+        """Most recently updated project still in the interview/review setup flow."""
+        in_setup: list[dict[str, Any]] = []
+        for project in self.list_projects(include_empty=True):
+            step = int(project.get("setup_step") or 0)
+            if step in {3, 4, 5}:
+                in_setup.append(project)
+        if not in_setup:
+            return None
+        return max(in_setup, key=lambda item: str(item.get("updated_at") or ""))
+
     def get_project(self, project_id: str) -> dict[str, Any] | None:
         conn = self.connect()
         row = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
@@ -930,6 +942,7 @@ class Store:
             "search_queries",
             "queries_fingerprint",
             "complete",
+            "setup_step",
         }
         unknown = set(fields) - allowed
         if unknown:
@@ -951,6 +964,8 @@ class Store:
                 payload[key] = json.dumps(payload[key])
         if "complete" in payload:
             payload["complete"] = 1 if payload["complete"] else 0
+        if "setup_step" in payload:
+            payload["setup_step"] = int(payload["setup_step"] or 0)
         payload["updated_at"] = _utc_now_iso()
 
         columns = ", ".join(f"{key} = ?" for key in payload)
@@ -990,6 +1005,7 @@ class Store:
         ):
             data[key] = Store._parse_json_list(data.get(key))
         data["complete"] = bool(data.get("complete", 0))
+        data["setup_step"] = int(data.get("setup_step") or 0)
         return data
 
     @staticmethod

--- a/rcopilot/store.py
+++ b/rcopilot/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -13,12 +14,14 @@ logger = logging.getLogger(__name__)
 
 DRAFT_STATUSES = frozenset({"pending", "approved", "rejected", "posted", "error", "scheduled"})
 DRAFT_KINDS = frozenset({"comment", "submission"})
+PROJECT_PURPOSES = frozenset({"product", "personal", "custom"})
+DEFAULT_PROJECT_ID = "default"
 
 _DRAFT_SELECT = """
             SELECT d.id, d.post_id, d.account_name, d.body, d.status, d.error, d.permalink,
                    d.created_at, d.updated_at, d.run_at, d.comment_id,
                    d.outcome_score, d.outcome_replies, d.outcome_removed, d.outcomes_polled_at,
-                   d.kind, d.submission_id, d.target_subreddit,
+                   d.kind, d.submission_id, d.target_subreddit, d.project_id,
                    COALESCE(p.subreddit, d.target_subreddit) AS subreddit,
                    COALESCE(p.title, d.title) AS title,
                    COALESCE(p.selftext, '') AS selftext,
@@ -29,7 +32,7 @@ _DRAFT_SELECT = """
                    p.relevance_score,
                    p.score_reasons
             FROM drafts d
-            LEFT JOIN posts p ON p.id = d.post_id
+            LEFT JOIN posts p ON p.id = d.post_id AND p.project_id = d.project_id
 """
 
 
@@ -84,8 +87,29 @@ class Store:
         conn = self.connect()
         conn.executescript(
             """
-            CREATE TABLE IF NOT EXISTS posts (
+            CREATE TABLE IF NOT EXISTS projects (
                 id TEXT PRIMARY KEY,
+                name TEXT NOT NULL DEFAULT '',
+                purpose TEXT NOT NULL DEFAULT 'product',
+                briefing TEXT NOT NULL DEFAULT '',
+                goals TEXT NOT NULL DEFAULT '[]',
+                links TEXT NOT NULL DEFAULT '[]',
+                interview_messages TEXT NOT NULL DEFAULT '[]',
+                tone TEXT NOT NULL DEFAULT '',
+                persona TEXT NOT NULL DEFAULT '',
+                avoid TEXT NOT NULL DEFAULT '',
+                subreddits TEXT NOT NULL DEFAULT '[]',
+                keywords TEXT NOT NULL DEFAULT '[]',
+                search_queries TEXT NOT NULL DEFAULT '[]',
+                queries_fingerprint TEXT NOT NULL DEFAULT '',
+                complete INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS posts (
+                id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'default',
                 subreddit TEXT NOT NULL,
                 title TEXT NOT NULL,
                 selftext TEXT NOT NULL,
@@ -93,12 +117,14 @@ class Store:
                 permalink TEXT NOT NULL,
                 created_utc REAL NOT NULL,
                 top_comments TEXT NOT NULL,
-                fetched_at TEXT NOT NULL
+                fetched_at TEXT NOT NULL,
+                PRIMARY KEY (project_id, id)
             );
 
             CREATE TABLE IF NOT EXISTS drafts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 post_id TEXT,
+                project_id TEXT NOT NULL DEFAULT 'default',
                 account_name TEXT NOT NULL,
                 body TEXT NOT NULL,
                 status TEXT NOT NULL,
@@ -109,8 +135,7 @@ class Store:
                 kind TEXT NOT NULL DEFAULT 'comment',
                 title TEXT,
                 target_subreddit TEXT,
-                submission_id TEXT,
-                FOREIGN KEY (post_id) REFERENCES posts(id)
+                submission_id TEXT
             );
 
             CREATE TABLE IF NOT EXISTS audit_events (
@@ -119,6 +144,7 @@ class Store:
                 action TEXT NOT NULL,
                 draft_id INTEGER,
                 post_id TEXT,
+                project_id TEXT,
                 detail TEXT
             );
 
@@ -128,6 +154,8 @@ class Store:
             """
         )
 
+        self._ensure_default_project(conn)
+        self._migrate_posts_project_scope(conn)
         self._add_column_if_missing(conn, "posts", "relevance_score", "REAL DEFAULT 0")
         self._add_column_if_missing(conn, "posts", "score_reasons", "TEXT DEFAULT '[]'")
         self._add_column_if_missing(conn, "posts", "skipped", "INTEGER DEFAULT 0")
@@ -143,31 +171,135 @@ class Store:
         self._add_column_if_missing(conn, "drafts", "title", "TEXT")
         self._add_column_if_missing(conn, "drafts", "target_subreddit", "TEXT")
         self._add_column_if_missing(conn, "drafts", "submission_id", "TEXT")
+        self._add_column_if_missing(conn, "drafts", "project_id", "TEXT NOT NULL DEFAULT 'default'")
+        self._add_column_if_missing(conn, "audit_events", "project_id", "TEXT")
         self._migrate_drafts_nullable_post_id(conn)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_drafts_project ON drafts(project_id, status)"
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_project ON posts(project_id)")
 
         conn.commit()
         logger.debug("Ensured schema at %s", self.db_path)
 
+    def _ensure_default_project(self, conn: sqlite3.Connection) -> None:
+        row = conn.execute("SELECT id FROM projects WHERE id = ?", (DEFAULT_PROJECT_ID,)).fetchone()
+        if row:
+            return
+        now = _utc_now_iso()
+        conn.execute(
+            """
+            INSERT INTO projects (
+                id, name, purpose, briefing, goals, links, interview_messages,
+                tone, persona, avoid, subreddits, keywords, search_queries,
+                queries_fingerprint, complete, created_at, updated_at
+            ) VALUES (?, '', 'product', '', '[]', '[]', '[]', '', '', '', '[]', '[]', '[]', '', 0, ?, ?)
+            """,
+            (DEFAULT_PROJECT_ID, now, now),
+        )
+
+    def _migrate_posts_project_scope(self, conn: sqlite3.Connection) -> None:
+        """Rebuild posts with composite PK (project_id, id) when upgrading older DBs."""
+        info = {row["name"]: row for row in conn.execute("PRAGMA table_info(posts)").fetchall()}
+        if not info:
+            return
+        pk_cols = [row["name"] for row in conn.execute("PRAGMA table_info(posts)").fetchall() if row["pk"]]
+        has_project = "project_id" in info
+        if has_project and "project_id" in pk_cols:
+            return
+
+        extra_cols = [
+            name
+            for name in (
+                "relevance_score",
+                "score_reasons",
+                "skipped",
+                "keywords_matched",
+                "intent_labels",
+            )
+            if name in info
+        ]
+        extra_select = "".join(f", {name}" for name in extra_cols)
+        extra_insert = "".join(f", {name}" for name in extra_cols)
+        project_select = "project_id" if has_project else f"'{DEFAULT_PROJECT_ID}'"
+
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute("DROP TABLE IF EXISTS posts_migrated")
+        conn.executescript(
+            f"""
+            CREATE TABLE posts_migrated (
+                id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'default',
+                subreddit TEXT NOT NULL,
+                title TEXT NOT NULL,
+                selftext TEXT NOT NULL,
+                url TEXT NOT NULL,
+                permalink TEXT NOT NULL,
+                created_utc REAL NOT NULL,
+                top_comments TEXT NOT NULL,
+                fetched_at TEXT NOT NULL,
+                relevance_score REAL DEFAULT 0,
+                score_reasons TEXT DEFAULT '[]',
+                skipped INTEGER DEFAULT 0,
+                keywords_matched TEXT DEFAULT '[]',
+                intent_labels TEXT DEFAULT '[]',
+                PRIMARY KEY (project_id, id)
+            );
+
+            INSERT INTO posts_migrated (
+                id, project_id, subreddit, title, selftext, url, permalink,
+                created_utc, top_comments, fetched_at
+                {extra_insert}
+            )
+            SELECT
+                id, {project_select}, subreddit, title, selftext, url, permalink,
+                created_utc, top_comments, fetched_at
+                {extra_select}
+            FROM posts;
+
+            DROP TABLE posts;
+            ALTER TABLE posts_migrated RENAME TO posts;
+            CREATE INDEX IF NOT EXISTS idx_posts_project ON posts(project_id);
+            """
+        )
+        conn.execute("PRAGMA foreign_keys = ON")
+
     def _migrate_drafts_nullable_post_id(self, conn: sqlite3.Connection) -> None:
-        """Allow NULL post_id for submission drafts; unique only when post_id is set."""
+        """Allow NULL post_id for submission drafts; unique per project when post_id is set."""
         info = {row["name"]: row for row in conn.execute("PRAGMA table_info(drafts)").fetchall()}
         post_col = info.get("post_id")
         if post_col is None:
             return
-        if int(post_col["notnull"] or 0) == 0:
+        has_project = "project_id" in info
+        unique_ok = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_drafts_post_id_unique'"
+        ).fetchone()
+        if int(post_col["notnull"] or 0) == 0 and unique_ok and has_project:
+            conn.execute("DROP INDEX IF EXISTS idx_drafts_post_id_unique")
             conn.execute(
                 """
-                CREATE UNIQUE INDEX IF NOT EXISTS idx_drafts_post_id_unique
-                ON drafts(post_id) WHERE post_id IS NOT NULL
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_drafts_project_post_unique
+                ON drafts(project_id, post_id) WHERE post_id IS NOT NULL
+                """
+            )
+            return
+        if int(post_col["notnull"] or 0) == 0 and has_project:
+            conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_drafts_project_post_unique
+                ON drafts(project_id, post_id) WHERE post_id IS NOT NULL
                 """
             )
             return
 
+        project_select = "project_id" if has_project else f"'{DEFAULT_PROJECT_ID}'"
+        conn.execute("PRAGMA foreign_keys = OFF")
         conn.executescript(
-            """
+            f"""
             CREATE TABLE drafts_migrated (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 post_id TEXT,
+                project_id TEXT NOT NULL DEFAULT 'default',
                 account_name TEXT NOT NULL,
                 body TEXT NOT NULL,
                 status TEXT NOT NULL,
@@ -184,18 +316,17 @@ class Store:
                 kind TEXT NOT NULL DEFAULT 'comment',
                 title TEXT,
                 target_subreddit TEXT,
-                submission_id TEXT,
-                FOREIGN KEY (post_id) REFERENCES posts(id)
+                submission_id TEXT
             );
 
             INSERT INTO drafts_migrated (
-                id, post_id, account_name, body, status, error, permalink,
+                id, post_id, project_id, account_name, body, status, error, permalink,
                 created_at, updated_at, run_at, comment_id,
                 outcome_score, outcome_replies, outcome_removed, outcomes_polled_at,
                 kind, title, target_subreddit, submission_id
             )
             SELECT
-                id, post_id, account_name, body, status, error, permalink,
+                id, post_id, {project_select}, account_name, body, status, error, permalink,
                 created_at, updated_at, run_at, comment_id,
                 outcome_score, outcome_replies, outcome_removed, outcomes_polled_at,
                 COALESCE(kind, 'comment'), title, target_subreddit, submission_id
@@ -206,10 +337,12 @@ class Store:
 
             CREATE INDEX IF NOT EXISTS idx_drafts_status ON drafts(status);
             CREATE INDEX IF NOT EXISTS idx_drafts_account_status ON drafts(account_name, status);
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_drafts_post_id_unique
-                ON drafts(post_id) WHERE post_id IS NOT NULL;
+            CREATE INDEX IF NOT EXISTS idx_drafts_project ON drafts(project_id, status);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_drafts_project_post_unique
+                ON drafts(project_id, post_id) WHERE post_id IS NOT NULL;
             """
         )
+        conn.execute("PRAGMA foreign_keys = ON")
 
     def upsert_post(
         self,
@@ -222,6 +355,7 @@ class Store:
         permalink: str,
         created_utc: float,
         top_comments: list[dict[str, Any]] | str,
+        project_id: str = DEFAULT_PROJECT_ID,
     ) -> None:
         conn = self.connect()
         comments_json = top_comments if isinstance(top_comments, str) else json.dumps(top_comments)
@@ -229,10 +363,10 @@ class Store:
         conn.execute(
             """
             INSERT INTO posts (
-                id, subreddit, title, selftext, url, permalink,
+                id, project_id, subreddit, title, selftext, url, permalink,
                 created_utc, top_comments, fetched_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(project_id, id) DO UPDATE SET
                 subreddit = excluded.subreddit,
                 title = excluded.title,
                 selftext = excluded.selftext,
@@ -242,11 +376,28 @@ class Store:
                 top_comments = excluded.top_comments,
                 fetched_at = excluded.fetched_at
             """,
-            (id, subreddit, title, selftext, url, permalink, created_utc, comments_json, fetched_at),
+            (
+                id,
+                project_id,
+                subreddit,
+                title,
+                selftext,
+                url,
+                permalink,
+                created_utc,
+                comments_json,
+                fetched_at,
+            ),
         )
         conn.commit()
 
-    def update_post(self, post_id: str, **fields: Any) -> None:
+    def update_post(
+        self,
+        post_id: str,
+        *,
+        project_id: str = DEFAULT_PROJECT_ID,
+        **fields: Any,
+    ) -> None:
         if not fields:
             return
 
@@ -262,22 +413,26 @@ class Store:
             raise ValueError(f"Unknown post fields: {', '.join(sorted(unknown))}")
 
         columns = ", ".join(f"{key} = ?" for key in fields)
-        values = list(fields.values()) + [post_id]
+        values = list(fields.values()) + [project_id, post_id]
 
         conn = self.connect()
-        conn.execute(f"UPDATE posts SET {columns} WHERE id = ?", values)
+        conn.execute(
+            f"UPDATE posts SET {columns} WHERE project_id = ? AND id = ?",
+            values,
+        )
         conn.commit()
 
     def list_posts(
         self,
         *,
+        project_id: str = DEFAULT_PROJECT_ID,
         undrafted: bool | None = None,
         skipped: bool | None = None,
         min_score: float | None = None,
     ) -> list[dict[str, Any]]:
         conn = self.connect()
-        clauses: list[str] = []
-        params: list[Any] = []
+        clauses: list[str] = ["p.project_id = ?"]
+        params: list[Any] = [project_id]
 
         if undrafted is True:
             clauses.append("d.id IS NULL")
@@ -292,8 +447,12 @@ class Store:
             clauses.append("p.relevance_score >= ?")
             params.append(min_score)
 
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        join = "LEFT JOIN drafts d ON d.post_id = p.id" if undrafted is not None else ""
+        where = f"WHERE {' AND '.join(clauses)}"
+        join = (
+            "LEFT JOIN drafts d ON d.post_id = p.id AND d.project_id = p.project_id"
+            if undrafted is not None
+            else ""
+        )
 
         rows = conn.execute(
             f"""
@@ -307,12 +466,19 @@ class Store:
         ).fetchall()
         return [self._row_post(row) for row in rows]
 
-    def list_posts_without_draft(self) -> list[dict[str, Any]]:
-        return self.list_posts(undrafted=True)
+    def list_posts_without_draft(
+        self, *, project_id: str = DEFAULT_PROJECT_ID
+    ) -> list[dict[str, Any]]:
+        return self.list_posts(project_id=project_id, undrafted=True)
 
-    def get_post(self, post_id: str) -> dict[str, Any] | None:
+    def get_post(
+        self, post_id: str, *, project_id: str = DEFAULT_PROJECT_ID
+    ) -> dict[str, Any] | None:
         conn = self.connect()
-        row = conn.execute("SELECT * FROM posts WHERE id = ?", (post_id,)).fetchone()
+        row = conn.execute(
+            "SELECT * FROM posts WHERE project_id = ? AND id = ?",
+            (project_id, post_id),
+        ).fetchone()
         return self._row_post(row) if row else None
 
     def create_draft(
@@ -325,6 +491,7 @@ class Store:
         kind: str = "comment",
         title: str | None = None,
         target_subreddit: str | None = None,
+        project_id: str = DEFAULT_PROJECT_ID,
     ) -> int:
         if status not in DRAFT_STATUSES:
             raise ValueError(f"Invalid draft status: {status}")
@@ -340,13 +507,14 @@ class Store:
         cursor = conn.execute(
             """
             INSERT INTO drafts (
-                post_id, account_name, body, status, error, permalink,
+                post_id, project_id, account_name, body, status, error, permalink,
                 created_at, updated_at, kind, title, target_subreddit
             )
-            VALUES (?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)
             """,
             (
                 post_id if kind == "comment" else None,
+                project_id,
                 account_name,
                 body,
                 status,
@@ -368,6 +536,7 @@ class Store:
         title: str,
         body: str,
         status: str = "pending",
+        project_id: str = DEFAULT_PROJECT_ID,
     ) -> int:
         return self.create_draft(
             "",
@@ -377,6 +546,7 @@ class Store:
             kind="submission",
             title=title.strip(),
             target_subreddit=subreddit.strip().lstrip("r/"),
+            project_id=project_id,
         )
 
     def update_draft(self, draft_id: int, **fields: Any) -> None:
@@ -428,20 +598,29 @@ class Store:
         ).fetchone()
         return self._row_draft(row) if row else None
 
-    def list_drafts(self, status: str | None = None) -> list[dict[str, Any]]:
+    def list_drafts(
+        self,
+        status: str | None = None,
+        *,
+        project_id: str | None = DEFAULT_PROJECT_ID,
+    ) -> list[dict[str, Any]]:
         conn = self.connect()
         if status is not None and status not in DRAFT_STATUSES and status != "all":
             raise ValueError(f"Invalid draft status: {status}")
 
-        if status is None or status == "all":
-            rows = conn.execute(
-                _DRAFT_SELECT + " ORDER BY d.created_at DESC"
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                _DRAFT_SELECT + " WHERE d.status = ? ORDER BY d.created_at DESC",
-                (status,),
-            ).fetchall()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if project_id:
+            clauses.append("d.project_id = ?")
+            params.append(project_id)
+        if status is not None and status != "all":
+            clauses.append("d.status = ?")
+            params.append(status)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = conn.execute(
+            _DRAFT_SELECT + f" {where} ORDER BY d.created_at DESC",
+            params,
+        ).fetchall()
         return [self._row_draft(row) for row in rows]
 
     def list_posted_for_outcomes(self, limit: int = 20) -> list[dict[str, Any]]:
@@ -473,15 +652,25 @@ class Store:
         ).fetchall()
         return [self._row_draft(row) for row in rows]
 
-    def list_scheduled(self) -> list[dict[str, Any]]:
+    def list_scheduled(self, *, project_id: str | None = DEFAULT_PROJECT_ID) -> list[dict[str, Any]]:
         conn = self.connect()
-        rows = conn.execute(
-            _DRAFT_SELECT
-            + """
-            WHERE d.status = 'scheduled'
-            ORDER BY d.run_at ASC
-            """
-        ).fetchall()
+        if project_id:
+            rows = conn.execute(
+                _DRAFT_SELECT
+                + """
+                WHERE d.status = 'scheduled' AND d.project_id = ?
+                ORDER BY d.run_at ASC
+                """,
+                (project_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                _DRAFT_SELECT
+                + """
+                WHERE d.status = 'scheduled'
+                ORDER BY d.run_at ASC
+                """
+            ).fetchall()
         return [self._row_draft(row) for row in rows]
 
     def cancel_schedule(self, draft_id: int) -> None:
@@ -498,36 +687,55 @@ class Store:
         *,
         draft_id: int | None = None,
         post_id: str | None = None,
+        project_id: str | None = None,
         detail: dict[str, Any] | None = None,
     ) -> int:
         conn = self.connect()
         cursor = conn.execute(
             """
-            INSERT INTO audit_events (created_at, action, draft_id, post_id, detail)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO audit_events (created_at, action, draft_id, post_id, project_id, detail)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
             (
                 _utc_now_iso(),
                 action,
                 draft_id,
                 post_id,
+                project_id,
                 json.dumps(detail) if detail else None,
             ),
         )
         conn.commit()
         return int(cursor.lastrowid)
 
-    def list_audit(self, limit: int = 100) -> list[dict[str, Any]]:
+    def list_audit(
+        self,
+        limit: int = 100,
+        *,
+        project_id: str | None = DEFAULT_PROJECT_ID,
+    ) -> list[dict[str, Any]]:
         conn = self.connect()
-        rows = conn.execute(
-            """
-            SELECT id, created_at, action, draft_id, post_id, detail
-            FROM audit_events
-            ORDER BY created_at DESC
-            LIMIT ?
-            """,
-            (limit,),
-        ).fetchall()
+        if project_id:
+            rows = conn.execute(
+                """
+                SELECT id, created_at, action, draft_id, post_id, project_id, detail
+                FROM audit_events
+                WHERE project_id IS NULL OR project_id = ?
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (project_id, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """
+                SELECT id, created_at, action, draft_id, post_id, project_id, detail
+                FROM audit_events
+                ORDER BY created_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
         results: list[dict[str, Any]] = []
         for row in rows:
             data = dict(row)
@@ -537,11 +745,19 @@ class Store:
             results.append(data)
         return results
 
-    def count_drafts_by_status(self) -> dict[str, int]:
+    def count_drafts_by_status(
+        self, *, project_id: str | None = DEFAULT_PROJECT_ID
+    ) -> dict[str, int]:
         conn = self.connect()
-        rows = conn.execute(
-            "SELECT status, COUNT(*) AS cnt FROM drafts GROUP BY status"
-        ).fetchall()
+        if project_id:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) AS cnt FROM drafts WHERE project_id = ? GROUP BY status",
+                (project_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) AS cnt FROM drafts GROUP BY status"
+            ).fetchall()
         counts = {status: 0 for status in DRAFT_STATUSES}
         for row in rows:
             counts[row["status"]] = int(row["cnt"])
@@ -575,6 +791,215 @@ class Store:
             (account_name,),
         ).fetchone()
         return _parse_iso(row["last_posted"]) if row and row["last_posted"] else None
+
+    def create_project(
+        self,
+        *,
+        purpose: str,
+        name: str = "",
+        project_id: str | None = None,
+        briefing: str = "",
+        goals: list[str] | None = None,
+        links: list[dict[str, Any]] | None = None,
+        interview_messages: list[dict[str, Any]] | None = None,
+        tone: str = "",
+        persona: str = "",
+        avoid: str = "",
+        subreddits: list[str] | None = None,
+        keywords: list[str] | None = None,
+        complete: bool = False,
+    ) -> dict[str, Any]:
+        if purpose not in PROJECT_PURPOSES:
+            raise ValueError(f"Invalid project purpose: {purpose}")
+        now = _utc_now_iso()
+        if project_id is None:
+            unused = self.get_project(DEFAULT_PROJECT_ID)
+            if unused and self._project_is_unused(unused):
+                updated = self.update_project(
+                    DEFAULT_PROJECT_ID,
+                    name=name,
+                    purpose=purpose,
+                    briefing=briefing,
+                    goals=goals or [],
+                    links=links or [],
+                    interview_messages=interview_messages or [],
+                    tone=tone,
+                    persona=persona,
+                    avoid=avoid,
+                    subreddits=subreddits or [],
+                    keywords=keywords or [],
+                    complete=complete,
+                )
+                if updated is None:
+                    raise RuntimeError("Failed to initialize default project")
+                return updated
+            pid = uuid.uuid4().hex
+        else:
+            pid = project_id
+        existing = self.get_project(pid)
+        if existing:
+            updated = self.update_project(
+                pid,
+                name=name or existing["name"],
+                purpose=purpose,
+                briefing=briefing,
+                goals=goals if goals is not None else existing["goals"],
+                links=links if links is not None else existing["links"],
+                interview_messages=(
+                    interview_messages
+                    if interview_messages is not None
+                    else existing["interview_messages"]
+                ),
+                tone=tone,
+                persona=persona,
+                avoid=avoid,
+                subreddits=subreddits if subreddits is not None else existing["subreddits"],
+                keywords=keywords if keywords is not None else existing["keywords"],
+                complete=complete,
+            )
+            if updated is None:
+                raise RuntimeError(f"Failed to update project {pid}")
+            return updated
+        conn = self.connect()
+        conn.execute(
+            """
+            INSERT INTO projects (
+                id, name, purpose, briefing, goals, links, interview_messages,
+                tone, persona, avoid, subreddits, keywords, search_queries,
+                queries_fingerprint, complete, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', '', ?, ?, ?)
+            """,
+            (
+                pid,
+                name,
+                purpose,
+                briefing,
+                json.dumps(goals or []),
+                json.dumps(links or []),
+                json.dumps(interview_messages or []),
+                tone,
+                persona,
+                avoid,
+                json.dumps(subreddits or []),
+                json.dumps(keywords or []),
+                1 if complete else 0,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        project = self.get_project(pid)
+        if project is None:
+            raise RuntimeError("Failed to create project")
+        return project
+
+    def get_project(self, project_id: str) -> dict[str, Any] | None:
+        conn = self.connect()
+        row = conn.execute("SELECT * FROM projects WHERE id = ?", (project_id,)).fetchone()
+        return self._row_project(row) if row else None
+
+    def list_projects(self, *, include_empty: bool = False) -> list[dict[str, Any]]:
+        conn = self.connect()
+        rows = conn.execute("SELECT * FROM projects ORDER BY created_at ASC").fetchall()
+        projects = [self._row_project(row) for row in rows]
+        if include_empty:
+            return projects
+        visible: list[dict[str, Any]] = []
+        for project in projects:
+            if (
+                project["complete"]
+                or (project.get("briefing") or "").strip()
+                or project.get("subreddits")
+            ):
+                visible.append(project)
+        return visible
+
+    def update_project(self, project_id: str, **fields: Any) -> dict[str, Any] | None:
+        allowed = {
+            "name",
+            "purpose",
+            "briefing",
+            "goals",
+            "links",
+            "interview_messages",
+            "tone",
+            "persona",
+            "avoid",
+            "subreddits",
+            "keywords",
+            "search_queries",
+            "queries_fingerprint",
+            "complete",
+        }
+        unknown = set(fields) - allowed
+        if unknown:
+            raise ValueError(f"Unknown project fields: {', '.join(sorted(unknown))}")
+        if "purpose" in fields and fields["purpose"] not in PROJECT_PURPOSES:
+            raise ValueError(f"Invalid project purpose: {fields['purpose']}")
+
+        payload = dict(fields)
+        json_fields = {
+            "goals",
+            "links",
+            "interview_messages",
+            "subreddits",
+            "keywords",
+            "search_queries",
+        }
+        for key in json_fields:
+            if key in payload and not isinstance(payload[key], str):
+                payload[key] = json.dumps(payload[key])
+        if "complete" in payload:
+            payload["complete"] = 1 if payload["complete"] else 0
+        payload["updated_at"] = _utc_now_iso()
+
+        columns = ", ".join(f"{key} = ?" for key in payload)
+        values = list(payload.values()) + [project_id]
+        conn = self.connect()
+        conn.execute(f"UPDATE projects SET {columns} WHERE id = ?", values)
+        conn.commit()
+        return self.get_project(project_id)
+
+    def list_post_ids(self, *, project_id: str = DEFAULT_PROJECT_ID) -> set[str]:
+        conn = self.connect()
+        rows = conn.execute(
+            "SELECT id FROM posts WHERE project_id = ?", (project_id,)
+        ).fetchall()
+        return {row["id"] for row in rows}
+
+    def draft_exists_for_post(
+        self, post_id: str, *, project_id: str = DEFAULT_PROJECT_ID
+    ) -> bool:
+        conn = self.connect()
+        row = conn.execute(
+            "SELECT id FROM drafts WHERE project_id = ? AND post_id = ?",
+            (project_id, post_id),
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _row_project(row: sqlite3.Row) -> dict[str, Any]:
+        data = dict(row)
+        for key in (
+            "goals",
+            "links",
+            "interview_messages",
+            "subreddits",
+            "keywords",
+            "search_queries",
+        ):
+            data[key] = Store._parse_json_list(data.get(key))
+        data["complete"] = bool(data.get("complete", 0))
+        return data
+
+    @staticmethod
+    def _project_is_unused(project: dict[str, Any]) -> bool:
+        return not (
+            project.get("complete")
+            or (project.get("briefing") or "").strip()
+            or project.get("interview_messages")
+            or project.get("subreddits")
+        )
 
     @staticmethod
     def _parse_json_list(value: Any) -> list[Any]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -111,7 +111,7 @@ def test_onboarding_progress_persists(client: TestClient) -> None:
 def test_onboarding_step_clamps(client: TestClient) -> None:
     response = client.put("/api/config", json={"onboarding_step": 99})
     assert response.status_code == 200
-    assert response.json()["onboarding_step"] == 4
+    assert response.json()["onboarding_step"] == 5
 
 
 def test_create_submission(client: TestClient) -> None:
@@ -185,7 +185,7 @@ def test_suggest_subreddits_api(
 ) -> None:
     monkeypatch.setattr(
         "rcopilot.llm.suggest_subreddits",
-        lambda llm, *, product, tone="", persona="", count=12: [
+        lambda llm, *, product, tone="", persona="", count=12, **kwargs: [
             "startups",
             "SaaS",
             "indiehackers",

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -1,0 +1,53 @@
+"""Interview briefing helpers (no live LLM)."""
+
+from __future__ import annotations
+
+from rcopilot.interview import EXTRACT_PROMPT, _parse_briefing_json, opening_message
+from rcopilot.llm import build_search_query_prompt
+from rcopilot.research import extract_urls
+
+
+def test_opening_prompts_differ_by_purpose() -> None:
+    product = opening_message("product")["content"].lower()
+    personal = opening_message("personal")["content"].lower()
+    custom = opening_message("custom")["content"].lower()
+    assert "product" in product
+    assert "yourself" in personal
+    assert "aim" in custom
+
+
+def test_extract_urls_skips_reddit() -> None:
+    text = "See https://example.com/docs and https://www.reddit.com/r/python plus https://redd.it/abc"
+    urls = extract_urls(text)
+    assert urls == ["https://example.com/docs"]
+
+
+def test_parse_briefing_json() -> None:
+    raw = """```json
+{"name": "Copilot", "briefing": "A local assistant", "goals": ["helpful comments"], "keywords": ["reddit"], "tone": "direct", "persona": "founder", "avoid": "hype"}
+```"""
+    data = _parse_briefing_json(raw)
+    assert data["name"] == "Copilot"
+    assert data["goals"] == ["helpful comments"]
+
+
+def test_search_query_prompt_differs_for_personal() -> None:
+    product = build_search_query_prompt(
+        product="A scheduling tool",
+        keywords=["looking for"],
+        subreddits=["SaaS"],
+        purpose="product",
+        goals=["signups"],
+    )
+    personal = build_search_query_prompt(
+        product="I am a staff designer",
+        keywords=["portfolio"],
+        subreddits=["design"],
+        purpose="personal",
+        goals=["share critique"],
+    )
+    assert "need this product" in product
+    assert "Purpose: product" in product
+    assert "not buying-intent" in personal
+    assert "Purpose: personal" in personal
+    assert EXTRACT_PROMPT

--- a/tests/test_interview.py
+++ b/tests/test_interview.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from rcopilot.interview import EXTRACT_PROMPT, _parse_briefing_json, opening_message
+from rcopilot.interview import (
+    EXTRACT_PROMPT,
+    READY_MARKER,
+    _parse_briefing_json,
+    opening_message,
+    split_ready_marker,
+    visible_interview_stream,
+)
 from rcopilot.llm import build_search_query_prompt
 from rcopilot.research import extract_urls
 
@@ -51,3 +58,22 @@ def test_search_query_prompt_differs_for_personal() -> None:
     assert "not buying-intent" in personal
     assert "Purpose: personal" in personal
     assert EXTRACT_PROMPT
+
+
+def test_ready_marker_is_stripped() -> None:
+    text = f"I'll set up the workspace from this.\n{READY_MARKER}\n"
+    visible, ready = split_ready_marker(text)
+    assert ready is True
+    assert visible == "I'll set up the workspace from this."
+    assert READY_MARKER not in visible
+    leftover, not_ready = split_ready_marker("What kind of design do you do?")
+    assert not_ready is False
+    assert leftover.startswith("What kind")
+
+
+def test_stream_hides_partial_ready_marker() -> None:
+    prefix = "I'll set this up now.\nREADY_FOR_WORK"
+    assert visible_interview_stream(prefix) == "I'll set this up now."
+    assert visible_interview_stream(f"I'll set this up now.\n{READY_MARKER}") == "I'll set this up now."
+    assert "READY" not in visible_interview_stream("What is the aim?")
+

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -106,6 +106,8 @@ def test_projects_api_create_and_active(tmp_path: Path) -> None:
     assert data["purpose"] == "personal"
     assert data["interview_messages"]
     assert data["interview_messages"][0]["role"] == "assistant"
+    assert data["setup_step"] == 4
+    assert client.get("/api/config").json()["setup_project"]["id"] == data["id"]
 
     listed = client.get("/api/projects")
     assert listed.status_code == 200
@@ -153,6 +155,20 @@ def test_complete_project_extracts_briefing(
     assert data["briefing"] == "Acme is a notes app."
     assert data["goals"] == ["helpful comments"]
     assert data["subreddits"] == ["productivity"]
+    assert data["setup_step"] == 5
+
+    config = client.get("/api/config").json()
+    setup = config.get("setup_project") or {}
+    assert setup.get("id") == created["id"]
+    assert setup.get("setup_step") == 5
+    assert setup.get("briefing") == "Acme is a notes app."
+
+    finished = client.patch(
+        f"/api/projects/{created['id']}", json={"complete": True}
+    )
+    assert finished.status_code == 200
+    assert finished.json()["setup_step"] == 0
+    assert client.get("/api/config").json().get("setup_project") is None
 
 
 def test_posts_and_drafts_api_honor_active_project(tmp_path: Path) -> None:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,188 @@
+"""Project workspace store and API tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rcopilot.api import create_app
+from rcopilot.config import write_example_config
+from rcopilot.projects import seed_projects_from_config
+from rcopilot.config import load_config
+from rcopilot.store import DEFAULT_PROJECT_ID, Store
+
+
+def _sample_post(store: Store, post_id: str = "p1", *, project_id: str = DEFAULT_PROJECT_ID) -> None:
+    store.upsert_post(
+        id=post_id,
+        project_id=project_id,
+        subreddit="python",
+        title="Hello",
+        selftext="body",
+        url="https://example.com",
+        permalink=f"https://reddit.com/r/python/comments/{post_id}",
+        created_utc=1.0,
+        top_comments=[],
+    )
+
+
+def test_seed_default_project_from_yaml_voice(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_example_config(config_path)
+    text = config_path.read_text(encoding="utf-8")
+    text = text.replace("db_path: rcopilot.db", f"db_path: {tmp_path / 'test.db'}")
+    config_path.write_text(text, encoding="utf-8")
+
+    config = load_config(config_path)
+    config.voice.product = "Reddit Copilot local assistant"
+    config.onboarding_complete = True
+    store = Store(config.db_path)
+    store.ensure_schema()
+    seeded = seed_projects_from_config(store, config)
+    assert seeded is not None
+    assert seeded["briefing"] == "Reddit Copilot local assistant"
+    assert seeded["purpose"] == "product"
+    assert seeded["complete"] is True
+    assert "python" in seeded["subreddits"]
+
+    again = seed_projects_from_config(store, config)
+    assert again is None
+
+
+def test_same_reddit_id_in_two_projects(tmp_path: Path) -> None:
+    store = Store(tmp_path / "test.db")
+    store.ensure_schema()
+    other = store.create_project(
+        purpose="personal",
+        name="Personal",
+        briefing="I am a designer",
+        project_id="personal",
+    )
+    _sample_post(store, "shared", project_id=DEFAULT_PROJECT_ID)
+    _sample_post(store, "shared", project_id=other["id"])
+
+    a = store.get_post("shared", project_id=DEFAULT_PROJECT_ID)
+    b = store.get_post("shared", project_id=other["id"])
+    assert a is not None and b is not None
+    store.update_post("shared", project_id=DEFAULT_PROJECT_ID, skipped=1)
+    assert store.get_post("shared", project_id=DEFAULT_PROJECT_ID)["skipped"] is True
+    assert store.get_post("shared", project_id=other["id"])["skipped"] is False
+
+    store.create_draft("shared", "default", "one", project_id=DEFAULT_PROJECT_ID)
+    store.create_draft("shared", "default", "two", project_id=other["id"])
+    assert len(store.list_drafts(project_id=DEFAULT_PROJECT_ID)) == 1
+    assert len(store.list_drafts(project_id=other["id"])) == 1
+
+
+def test_list_posts_scoped_to_project(tmp_path: Path) -> None:
+    store = Store(tmp_path / "test.db")
+    store.ensure_schema()
+    other = store.create_project(
+        purpose="custom",
+        name="Custom",
+        briefing="Collect recipes",
+        project_id="custom",
+    )
+    _sample_post(store, "a", project_id=DEFAULT_PROJECT_ID)
+    _sample_post(store, "b", project_id=other["id"])
+    assert [p["id"] for p in store.list_posts(project_id=DEFAULT_PROJECT_ID)] == ["a"]
+    assert [p["id"] for p in store.list_posts(project_id=other["id"])] == ["b"]
+
+
+def test_projects_api_create_and_active(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_example_config(config_path)
+    text = config_path.read_text(encoding="utf-8")
+    text = text.replace("db_path: rcopilot.db", f"db_path: {tmp_path / 'test.db'}")
+    config_path.write_text(text, encoding="utf-8")
+    (tmp_path / ".env").write_text("LLM_API_KEY=test-key\n", encoding="utf-8")
+    client = TestClient(create_app(config_path=str(config_path)))
+
+    created = client.post("/api/projects", json={"purpose": "personal"})
+    assert created.status_code == 200, created.text
+    data = created.json()
+    assert data["purpose"] == "personal"
+    assert data["interview_messages"]
+    assert data["interview_messages"][0]["role"] == "assistant"
+
+    listed = client.get("/api/projects")
+    assert listed.status_code == 200
+    listed_ids = [item["id"] for item in listed.json()["projects"]]
+    assert data["id"] not in listed_ids
+
+    second = client.post("/api/projects", json={"purpose": "custom"}).json()
+    assert second["id"] != data["id"]
+    listed = client.get("/api/projects").json()
+    assert listed["active_project_id"] != second["id"]
+    assert second["id"] not in [item["id"] for item in listed["projects"]]
+
+    switched = client.put("/api/projects/active", json={"id": second["id"]})
+    assert switched.status_code == 200
+    assert switched.json()["active_project_id"] == second["id"]
+
+def test_complete_project_extracts_briefing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_example_config(config_path)
+    text = config_path.read_text(encoding="utf-8")
+    text = text.replace("db_path: rcopilot.db", f"db_path: {tmp_path / 'test.db'}")
+    config_path.write_text(text, encoding="utf-8")
+    (tmp_path / ".env").write_text("LLM_API_KEY=test-key\n", encoding="utf-8")
+    client = TestClient(create_app(config_path=str(config_path)))
+    created = client.post("/api/projects", json={"purpose": "product"}).json()
+
+    monkeypatch.setattr(
+        "rcopilot.api.complete_workspace",
+        lambda llm, *, purpose, messages, count=12: {
+            "name": "Acme",
+            "briefing": "Acme is a notes app.",
+            "goals": ["helpful comments"],
+            "keywords": ["notes app"],
+            "tone": "direct",
+            "persona": "founder",
+            "avoid": "hype",
+            "subreddits": ["productivity"],
+        },
+    )
+    response = client.post(f"/api/projects/{created['id']}/complete")
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["briefing"] == "Acme is a notes app."
+    assert data["goals"] == ["helpful comments"]
+    assert data["subreddits"] == ["productivity"]
+
+
+def test_posts_and_drafts_api_honor_active_project(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    write_example_config(config_path)
+    text = config_path.read_text(encoding="utf-8")
+    text = text.replace("db_path: rcopilot.db", f"db_path: {tmp_path / 'test.db'}")
+    config_path.write_text(text, encoding="utf-8")
+    (tmp_path / ".env").write_text("LLM_API_KEY=test-key\n", encoding="utf-8")
+    client = TestClient(create_app(config_path=str(config_path)))
+
+    first = client.post("/api/projects", json={"purpose": "product"}).json()
+    second = client.post("/api/projects", json={"purpose": "personal"}).json()
+    config = load_config(config_path)
+    store = Store(config.db_path)
+    _sample_post(store, "alpha", project_id=first["id"])
+    _sample_post(store, "beta", project_id=second["id"])
+    store.create_draft("alpha", "default", "one", project_id=first["id"])
+    store.create_draft("beta", "default", "two", project_id=second["id"])
+
+    switched = client.put("/api/projects/active", json={"id": first["id"]})
+    assert switched.status_code == 200
+    posts = client.get("/api/posts").json()["posts"]
+    assert [item["id"] for item in posts] == ["alpha"]
+    drafts = client.get("/api/drafts?status=all").json()["drafts"]
+    assert [item["post_id"] for item in drafts] == ["alpha"]
+
+    client.put("/api/projects/active", json={"id": second["id"]})
+    posts = client.get("/api/posts").json()["posts"]
+    assert [item["id"] for item in posts] == ["beta"]
+    drafts = client.get("/api/drafts?status=all").json()["drafts"]
+    assert [item["post_id"] for item in drafts] == ["beta"]
+

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -112,7 +112,7 @@ def test_product_blurb_matches_intent() -> None:
     )
     assert score >= 0.2
     assert any(term in matched for term in ("engagement assistant", "copilot", "assistant", "engagement"))
-    assert any("product match" in reason for reason in reasons)
+    assert any("context match" in reason for reason in reasons)
     assert any("looking-for-tool" in reason for reason in reasons)
     assert "looking-for-tool" in labels
 
@@ -123,7 +123,7 @@ def test_unrelated_thread_does_not_get_product_match() -> None:
         ["looking for"],
         product="Reddit Copilot — a local-first Reddit engagement assistant.",
     )
-    assert "product match" not in " ".join(reasons)
+    assert "context match" not in " ".join(reasons)
     assert "copilot" not in matched
     assert score <= 0.2
     assert any("weak intent" in reason for reason in reasons)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "16.3.4",
         "react": "19.2.8",
-        "react-dom": "19.2.8"
+        "react-dom": "19.2.8",
+        "react-markdown": "^10.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1615,12 +1616,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1634,6 +1661,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1650,7 +1692,6 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1665,6 +1706,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.69.0",
@@ -1960,6 +2007,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.12.2",
@@ -2571,6 +2624,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2728,6 +2791,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2743,6 +2816,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/client-only": {
@@ -2770,6 +2883,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2804,7 +2927,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2872,7 +2994,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2884,6 +3005,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2929,6 +3063,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2937,6 +3080,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -3614,6 +3770,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3623,6 +3789,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4056,6 +4228,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4071,6 +4283,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -4110,6 +4332,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4123,6 +4351,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4283,6 +4535,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -4358,6 +4620,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -4409,6 +4681,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -5019,6 +5303,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5062,6 +5356,159 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5071,6 +5518,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5113,7 +6002,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5472,6 +6360,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5579,6 +6492,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5638,6 +6561,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5680,6 +6630,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -6052,6 +7035,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -6187,6 +7180,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6208,6 +7215,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-jsx": {
@@ -6339,6 +7364,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6541,6 +7586,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -6618,6 +7750,34 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -6776,6 +7936,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "16.3.4",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,13 +1,13 @@
 import { Suspense } from "react";
 import { OnboardingFlow } from "@/components/onboarding/onboarding-flow";
-import { Mascot } from "@/components/ui/mascot";
+import { PageStatus } from "@/components/ui/page-status";
 
 export default function OnboardingPage() {
   return (
     <Suspense
       fallback={
         <div className="flex min-h-screen items-center justify-center bg-surface">
-          <Mascot mood="thinking" />
+          <PageStatus kind="loading" message="Getting things ready…" />
         </div>
       }
     >

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,8 +9,13 @@ export default async function HomePage() {
   try {
     const res = await fetch(`${api}/api/config`, { cache: "no-store" });
     if (res.ok) {
-      const config = (await res.json()) as { onboarding_complete?: boolean };
-      onboardingComplete = Boolean(config.onboarding_complete);
+      const config = (await res.json()) as {
+        onboarding_complete?: boolean;
+        projects?: { id: string }[];
+      };
+      onboardingComplete =
+        Boolean(config.onboarding_complete) &&
+        Boolean(config.projects && config.projects.length > 0);
     }
   } catch {
     // API down — send first-run users to onboarding

--- a/web/src/components/activity/activity-view.tsx
+++ b/web/src/components/activity/activity-view.tsx
@@ -5,8 +5,7 @@ import { getActivity, type ActivityEvent } from "@/lib/api";
 import { formatRelativeTime } from "@/lib/format";
 import { ApiDownNotice } from "@/components/ui/notice";
 import { Surface } from "@/components/ui/surface";
-import { Mascot } from "@/components/ui/mascot";
-import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { PageStatus } from "@/components/ui/page-status";
 
 export function ActivityView() {
   const [items, setItems] = useState<ActivityEvent[]>([]);
@@ -50,18 +49,12 @@ export function ActivityView() {
         )}
 
         {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Mascot mood="thinking" />
-          </div>
+          <PageStatus kind="loading" message="Loading activity…" />
         ) : items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <AsciiAccent className="mb-4" />
-            <Mascot mood="neutral" className="mb-4" />
-            <p className="max-w-sm text-[15px] text-ink-2">
-              No activity yet. Actions will show up here as you review and
-              post.
-            </p>
-          </div>
+          <PageStatus
+            kind="empty"
+            message="No activity yet. Actions will show up here as you review and post."
+          />
         ) : (
           <ul className="space-y-2">
             {items.map((item) => (

--- a/web/src/components/discover/discover-view.tsx
+++ b/web/src/components/discover/discover-view.tsx
@@ -11,8 +11,7 @@ import {
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { ApiDownNotice, Notice } from "@/components/ui/notice";
-import { Mascot } from "@/components/ui/mascot";
-import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { PageStatus } from "@/components/ui/page-status";
 import { Surface } from "@/components/ui/surface";
 import { SubredditName } from "@/components/ui/subreddit-name";
 import { IconPlus, IconSkip, IconRefresh } from "@/components/ui/icons";
@@ -218,19 +217,24 @@ export function DiscoverView() {
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
-        {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Mascot mood="thinking" />
-          </div>
+        {loading || fetching ? (
+          <PageStatus
+            kind="loading"
+            message={
+              fetching
+                ? "Fetching threads from your communities…"
+                : "Looking through your communities…"
+            }
+          />
         ) : filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <AsciiAccent className="mb-4" />
-            <Mascot mood="sleepy" className="mb-4" />
-            <p className="max-w-sm text-[15px] text-ink-2">
-              No intent-matched threads right now. Fetch threads, or check
-              subreddits and what you make in Settings.
-            </p>
-          </div>
+          <PageStatus
+            kind="empty"
+            message={
+              query.trim() || labelFilter
+                ? "Nothing matches that filter."
+                : "No matching threads yet. Fetch a round, or check subreddits and what you make in Settings."
+            }
+          />
         ) : (
           <div className="grid gap-3">
             {filtered.map((post) => (

--- a/web/src/components/draft/draft-detail-view.tsx
+++ b/web/src/components/draft/draft-detail-view.tsx
@@ -31,7 +31,7 @@ import { Pill } from "@/components/ui/pill";
 import { Surface } from "@/components/ui/surface";
 import { Kbd, KeyCombo } from "@/components/ui/kbd";
 import { Dots } from "@/components/ui/dots";
-import { Mascot } from "@/components/ui/mascot";
+import { PageStatus } from "@/components/ui/page-status";
 import { PostedDetailView } from "@/components/draft/posted-detail-view";
 import { BestTimeChips } from "@/components/schedule/best-time-chips";
 import { SubredditName } from "@/components/ui/subreddit-name";
@@ -204,9 +204,11 @@ export function DraftDetailView({ id }: { id: number }) {
 
   if (loading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Mascot mood="thinking" />
-      </div>
+      <PageStatus
+        kind="loading"
+        message="Opening this draft…"
+        className="h-full"
+      />
     );
   }
 

--- a/web/src/components/onboarding/interview-chat.tsx
+++ b/web/src/components/onboarding/interview-chat.tsx
@@ -13,6 +13,7 @@ export function InterviewChat({
   streaming,
   researched,
   busy,
+  setup,
   disabled,
   onSend,
 }: {
@@ -20,6 +21,7 @@ export function InterviewChat({
   streaming: string;
   researched: ProjectLink[];
   busy?: boolean;
+  setup?: boolean;
   disabled?: boolean;
   onSend: (text: string) => void;
 }) {
@@ -91,6 +93,10 @@ export function InterviewChat({
                     aria-hidden="true"
                   />
                 </div>
+              ) : setup ? (
+                <p className="text-[14px] leading-[1.55] text-ink">
+                  Setting up your workspace…
+                </p>
               ) : (
                 <Dots className="py-1" />
               )}
@@ -103,11 +109,10 @@ export function InterviewChat({
             {researched.map((item) => (
               <span
                 key={item.url}
-                className="rounded-full bg-well px-2.5 py-1 text-[12px] text-ink-2"
+                title={item.title || item.url}
+                className="max-w-[min(100%,18rem)] truncate rounded-full bg-well px-2.5 py-1 text-[12px] text-ink-2"
               >
-                {item.ok === false
-                  ? `Couldn’t read ${hostOf(item.url)}`
-                  : `Read ${item.title || hostOf(item.url)}`}
+                {researchLabel(item)}
               </span>
             ))}
           </div>
@@ -150,4 +155,25 @@ function hostOf(url: string) {
   } catch {
     return url;
   }
+}
+
+function githubRepo(url: string) {
+  try {
+    const parts = new URL(url).pathname.split("/").filter(Boolean);
+    if (parts.length >= 2) return `${parts[0]}/${parts[1]}`;
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function researchLabel(item: ProjectLink) {
+  const host = hostOf(item.url);
+  if (item.ok === false) return `Couldn’t read ${host}`;
+  if (host === "github.com") {
+    return `Read ${githubRepo(item.url) || host}`;
+  }
+  const title = (item.title || "").replace(/\s*[·|].*$/, "").trim();
+  if (!title || title.toLowerCase() === host) return `Read ${host}`;
+  return title.length > 36 ? `Read ${title.slice(0, 33)}…` : `Read ${title}`;
 }

--- a/web/src/components/onboarding/interview-chat.tsx
+++ b/web/src/components/onboarding/interview-chat.tsx
@@ -79,8 +79,9 @@ export function InterviewChat({
             aria-busy="true"
           >
             <Mascot
-              mood="happy"
-              talking
+              mood={setup ? "thinking" : "happy"}
+              talking={!setup}
+              searching={setup}
               size={40}
               className="mt-0.5 shrink-0"
             />

--- a/web/src/components/onboarding/interview-chat.tsx
+++ b/web/src/components/onboarding/interview-chat.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { InterviewMessage, ProjectLink } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { IconSend } from "@/components/ui/icons";
+import { Mascot } from "@/components/ui/mascot";
+import { MarkdownBody } from "@/components/ui/markdown";
+import { Dots } from "@/components/ui/dots";
+
+export function InterviewChat({
+  messages,
+  streaming,
+  researched,
+  busy,
+  disabled,
+  onSend,
+}: {
+  messages: InterviewMessage[];
+  streaming: string;
+  researched: ProjectLink[];
+  busy?: boolean;
+  disabled?: boolean;
+  onSend: (text: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const end = useRef<HTMLDivElement>(null);
+  const visible = messages.filter((item) => item.role !== "system");
+  const waiting = Boolean(busy) && !streaming;
+  const speaking = Boolean(streaming);
+
+  useEffect(() => {
+    end.current?.scrollIntoView({ block: "end" });
+  }, [visible, streaming, researched, waiting]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || disabled) return;
+    setDraft("");
+    onSend(text);
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-1 py-1">
+        {visible.map((item, index) =>
+          item.role === "user" ? (
+            <div
+              key={`user-${index}`}
+              className="flex justify-end pl-12 motion-safe:animate-rise-in"
+            >
+              <div className="max-w-[78%] rounded-[18px] rounded-br-md bg-ink px-3.5 py-2.5 text-left squircle">
+                <MarkdownBody text={item.content} tone="user" />
+              </div>
+            </div>
+          ) : (
+            <div
+              key={`assistant-${index}`}
+              className="flex items-start gap-2.5 pr-8 motion-safe:animate-rise-in"
+            >
+              <Mascot
+                mood="happy"
+                size={40}
+                className="mt-0.5 shrink-0"
+              />
+              <div className="min-w-0 max-w-[78%] rounded-[18px] rounded-bl-md bg-well px-3.5 py-2.5 text-left squircle">
+                <MarkdownBody text={item.content} />
+              </div>
+            </div>
+          ),
+        )}
+
+        {(waiting || speaking) && (
+          <div
+            className="flex items-start gap-2.5 pr-8"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <Mascot
+              mood="happy"
+              talking
+              size={40}
+              className="mt-0.5 shrink-0"
+            />
+            <div className="min-w-0 max-w-[78%] rounded-[18px] rounded-bl-md bg-well px-3.5 py-2.5 text-left squircle">
+              {speaking ? (
+                <div className="[&_p:last-child]:mb-0 [&_p:last-child]:inline">
+                  <MarkdownBody text={streaming} className="inline" />
+                  <span
+                    className="ml-0.5 inline-block h-[0.9em] w-[2px] translate-y-[2px] bg-ink motion-safe:animate-caret"
+                    aria-hidden="true"
+                  />
+                </div>
+              ) : (
+                <Dots className="py-1" />
+              )}
+            </div>
+          </div>
+        )}
+
+        {researched.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pl-[50px]">
+            {researched.map((item) => (
+              <span
+                key={item.url}
+                className="rounded-full bg-well px-2.5 py-1 text-[12px] text-ink-2"
+              >
+                {item.ok === false
+                  ? `Couldn’t read ${hostOf(item.url)}`
+                  : `Read ${item.title || hostOf(item.url)}`}
+              </span>
+            ))}
+          </div>
+        )}
+        <div ref={end} />
+      </div>
+
+      <div className="mt-3 flex items-end gap-2">
+        <textarea
+          value={draft}
+          disabled={disabled}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          rows={2}
+          placeholder="Write a reply…"
+          aria-label="Message"
+          className="min-h-[56px] max-h-32 flex-1 resize-none rounded-field bg-well px-3 py-2.5 text-[14px] leading-relaxed text-ink placeholder:text-ink-4 focus:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-accent-200 squircle"
+        />
+        <Button
+          size="sm"
+          disabled={disabled || !draft.trim()}
+          onClick={submit}
+          leading={<IconSend size={14} />}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function hostOf(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/web/src/components/onboarding/onboarding-flow.tsx
+++ b/web/src/components/onboarding/onboarding-flow.tsx
@@ -1,16 +1,22 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
+  completeProject,
+  createProject,
+  fetchThreads,
   getConfig,
+  getProject,
+  patchProject,
   putConfig,
   putSecrets,
+  setActiveProject,
   startOAuth,
-  fetchThreads,
-  suggestSubreddits,
-  type AppConfig,
-  type ConfigUpdate,
+  streamInterview,
+  type InterviewMessage,
+  type ProjectLink,
+  type ProjectPurpose,
 } from "@/lib/api";
 import { cn } from "@/lib/cn";
 import { Button } from "@/components/ui/button";
@@ -18,7 +24,10 @@ import { MeuxeMark, Mascot } from "@/components/ui/mascot";
 import { Field, Label, Input, Textarea, Hint } from "@/components/ui/field";
 import { Notice } from "@/components/ui/notice";
 import { TagInput } from "@/components/ui/tag-input";
-import { IconRefresh } from "@/components/ui/icons";
+import { ChoiceCard } from "@/components/ui/choice-card";
+import { InterviewChat } from "@/components/onboarding/interview-chat";
+
+const ACCOUNT_STEPS = 3;
 
 const STEPS = [
   {
@@ -34,138 +43,158 @@ const STEPS = [
     mood: "thinking" as const,
   },
   {
-    title: "Describe your voice",
-    subtitle: "What you build and how you sound when you help people.",
-    mood: "happy" as const,
-  },
-  {
     title: "Connect your LLM",
-    subtitle: "OpenAI-compatible API — used for drafts and subreddit suggestions.",
+    subtitle:
+      "OpenAI-compatible API — used for drafts, briefing, and subreddit suggestions.",
     mood: "sleepy" as const,
   },
   {
-    title: "Pick your communities",
+    title: "What is this for?",
+    subtitle: "Each workspace can be a product, personal, or something you define.",
+    mood: "happy" as const,
+  },
+  {
+    title: "Tell us more",
     subtitle:
-      "We’ll suggest subreddits from your voice. Add or remove until it feels right.",
+      "A short conversation so Copilot can pick communities and write in your voice.",
+    mood: "thinking" as const,
+  },
+  {
+    title: "Review your workspace",
+    subtitle: "Edit the goals and communities, then we’ll fetch the first threads.",
     mood: "surprised" as const,
   },
 ];
 
-function clampStep(value: number | undefined): number {
+const PURPOSES: { id: ProjectPurpose; title: string; description: string }[] = [
+  {
+    id: "product",
+    title: "A product",
+    description:
+      "Find threads where people need what you make, then draft helpful replies.",
+  },
+  {
+    id: "personal",
+    title: "Personal",
+    description:
+      "Show up as yourself — expertise, job search, hobby communities.",
+  },
+  {
+    id: "custom",
+    title: "Custom",
+    description: "Describe exactly what you want this copilot to do.",
+  },
+];
+
+const OPENINGS: Record<ProjectPurpose, string> = {
+  product:
+    "Tell me about your product. What is it, who is it for, and what problem does it solve? You can also paste links to the site, docs, or a launch post.",
+  personal:
+    "Tell me about yourself — what you do, the communities you care about, and how you want to show up on Reddit.",
+  custom:
+    "What do you want to do with this copilot? What is your aim — the more specific, the better I can set up discovery and drafts.",
+};
+
+function messagesWithOpening(
+  purpose: ProjectPurpose,
+  messages: InterviewMessage[],
+): InterviewMessage[] {
+  if (messages.some((item) => item.role === "assistant")) return messages;
+  return [{ role: "assistant", content: OPENINGS[purpose] }, ...messages];
+}
+
+function clampStep(value: number | undefined, max: number): number {
   if (!Number.isFinite(value)) return 0;
-  return Math.max(0, Math.min(Math.trunc(value as number), STEPS.length - 1));
+  return Math.max(0, Math.min(Math.trunc(value as number), max));
 }
 
 export function OnboardingFlow() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const isNewProject = searchParams.get("new") === "1";
+  const isRerun = searchParams.get("briefing") === "1";
   const [step, setStep] = useState(0);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [connecting, setConnecting] = useState(false);
-  const [suggesting, setSuggesting] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const [connectedName, setConnectedName] = useState("");
   const [hasClientId, setHasClientId] = useState(false);
   const [hasApiKey, setHasApiKey] = useState(false);
+  const [accountReady, setAccountReady] = useState(false);
   const [redirectUri, setRedirectUri] = useState(
     "http://127.0.0.1:8000/api/oauth/callback",
   );
-  const suggestedOnce = useRef(false);
 
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
-  const [productDesc, setProductDesc] = useState("");
-  const [tone, setTone] = useState("");
-  const [persona, setPersona] = useState("");
-  const [subreddits, setSubreddits] = useState<string[]>([]);
-  const [keywords, setKeywords] = useState<string[]>([]);
   const [llmModel, setLlmModel] = useState("gpt-4o-mini");
   const [llmBaseUrl, setLlmBaseUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
 
-  function applyConfig(config: AppConfig) {
-    if (config.oauth_redirect_uri) setRedirectUri(config.oauth_redirect_uri);
-    const account = config.accounts?.[0];
-    setHasClientId(Boolean(account?.has_client_id));
-    setHasApiKey(Boolean(config.has_api_key));
-    if (account?.connected_username) {
-      setConnectedName(account.connected_username);
-    } else if (account?.has_oauth) {
-      setConnectedName("your account");
-    }
-    setProductDesc(config.voice?.product ?? "");
-    setTone(config.voice?.tone ?? "");
-    setPersona(config.voice?.persona ?? "");
-    setSubreddits(config.subreddits ?? []);
-    setKeywords(config.discovery?.keywords ?? []);
-    if (config.llm?.model) setLlmModel(config.llm.model);
-    setLlmBaseUrl(config.llm?.base_url ?? "");
-  }
+  const [purpose, setPurpose] = useState<ProjectPurpose | null>(null);
+  const [projectId, setProjectId] = useState("");
+  const [messages, setMessages] = useState<InterviewMessage[]>([]);
+  const [streaming, setStreaming] = useState("");
+  const [replying, setReplying] = useState(false);
+  const [researched, setResearched] = useState<ProjectLink[]>([]);
+  const [workspaceName, setWorkspaceName] = useState("");
+  const [briefing, setBriefing] = useState("");
+  const [goals, setGoals] = useState<string[]>([]);
+  const [subreddits, setSubreddits] = useState<string[]>([]);
+  const [keywords, setKeywords] = useState<string[]>([]);
 
-  async function persist(nextStep: number, extra?: ConfigUpdate) {
-    await putConfig({
-      onboarding_step: nextStep,
-      subreddits,
-      voice: {
-        product: productDesc,
-        tone,
-        persona,
-      },
-      discovery: {
-        keywords,
-      },
-      llm: {
-        model: llmModel,
-        base_url: llmBaseUrl || undefined,
-      },
-      ...extra,
-    });
-  }
-
-  async function runSuggest(force = false) {
-    if (!productDesc.trim()) {
-      setError("Describe what you make first, then we can suggest communities.");
-      return;
-    }
-    if (!force && subreddits.length > 0) return;
-    setSuggesting(true);
-    setError(null);
-    try {
-      const data = await suggestSubreddits({
-        product: productDesc,
-        tone,
-        persona,
-        count: 12,
-      });
-      setSubreddits(data.subreddits ?? []);
-      suggestedOnce.current = true;
-    } catch (e) {
-      setError(
-        e instanceof Error
-          ? e.message
-          : "Could not suggest subreddits. Add some manually.",
-      );
-    } finally {
-      setSuggesting(false);
-    }
-  }
+  const skipAccount = accountReady || isNewProject || isRerun;
+  const firstVisible = isRerun ? 4 : skipAccount ? ACCOUNT_STEPS : 0;
+  const visibleSteps = STEPS.map((_, i) => i).filter((i) => i >= firstVisible);
+  const current = STEPS[step];
 
   useEffect(() => {
     let cancelled = false;
     getConfig()
       .then((config) => {
         if (cancelled) return;
-        applyConfig(config);
+        if (config.oauth_redirect_uri) setRedirectUri(config.oauth_redirect_uri);
+        const account = config.accounts?.[0];
+        setHasClientId(Boolean(account?.has_client_id));
+        setHasApiKey(Boolean(config.has_api_key));
+        if (account?.connected_username) {
+          setConnectedName(account.connected_username);
+        } else if (account?.has_oauth) {
+          setConnectedName("your account");
+        }
+        if (config.llm?.model) setLlmModel(config.llm.model);
+        setLlmBaseUrl(config.llm?.base_url ?? "");
+        const redditOk = Boolean(account?.has_oauth || account?.connected_username);
+        const llmOk = Boolean(config.has_api_key);
+        const readyAccount = redditOk && llmOk && Boolean(account?.has_client_id);
+        setAccountReady(readyAccount);
+
         const reddit = searchParams.get("reddit");
-        let nextStep = clampStep(config.onboarding_step);
-        // Migrate older saves that stored "subreddits" as step 3 before LLM swap.
-        if (
-          nextStep === 3 &&
-          !(config.subreddits?.length) &&
-          !config.has_api_key
-        ) {
-          nextStep = 3; // LLM step in new order
+        let nextStep = clampStep(config.onboarding_step, STEPS.length - 1);
+        if (isRerun && readyAccount && config.active_project_id) {
+          nextStep = 4;
+          void getProject(config.active_project_id)
+            .then((project) => {
+              if (cancelled) return;
+              setProjectId(project.id);
+              setPurpose(project.purpose);
+              setMessages(
+                messagesWithOpening(
+                  project.purpose,
+                  project.interview_messages ?? [],
+                ),
+              );
+              setResearched(project.links ?? []);
+            })
+            .catch(() => {
+              if (!cancelled) setError("Could not load this workspace.");
+            });
+        } else if (isNewProject && readyAccount) {
+          nextStep = ACCOUNT_STEPS;
+        } else if (readyAccount && nextStep < ACCOUNT_STEPS) {
+          nextStep = ACCOUNT_STEPS;
         }
         if (reddit === "connected" || reddit === "error") {
           nextStep = Math.max(nextStep, 1);
@@ -186,33 +215,18 @@ export function OnboardingFlow() {
     return () => {
       cancelled = true;
     };
-  }, [searchParams]);
+  }, [searchParams, isNewProject, isRerun]);
 
-  useEffect(() => {
-    if (!ready) return;
-    const timer = window.setTimeout(() => {
-      void persist(step);
-    }, 500);
-    return () => window.clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    ready,
-    step,
-    productDesc,
-    tone,
-    persona,
-    subreddits,
-    keywords,
-    llmModel,
-    llmBaseUrl,
-  ]);
-
-  useEffect(() => {
-    if (!ready || step !== 4) return;
-    if (suggestedOnce.current || subreddits.length > 0) return;
-    void runSuggest(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ready, step]);
+  async function persistAccount(nextStep: number) {
+    if (isNewProject || isRerun) return;
+    await putConfig({
+      onboarding_step: nextStep,
+      llm: {
+        model: llmModel,
+        base_url: llmBaseUrl || undefined,
+      },
+    });
+  }
 
   async function saveSecretsIfPresent() {
     const secrets: {
@@ -234,12 +248,101 @@ export function OnboardingFlow() {
     }
   }
 
-  async function finish() {
-    setLoading(true);
+  async function handleConnect() {
+    setConnecting(true);
     setError(null);
     try {
       await saveSecretsIfPresent();
-      await persist(STEPS.length - 1, { onboarding_complete: true });
+      await persistAccount(1);
+      const { authorize_url } = await startOAuth("/onboarding");
+      window.location.href = authorize_url;
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Could not start Reddit sign-in.",
+      );
+      setConnecting(false);
+    }
+  }
+
+  async function startInterview(nextPurpose: ProjectPurpose) {
+    if (projectId && purpose === nextPurpose) return;
+    const project = await createProject(nextPurpose);
+    setProjectId(project.id);
+    setPurpose(nextPurpose);
+    setMessages(
+      messagesWithOpening(nextPurpose, project.interview_messages ?? []),
+    );
+    setResearched([]);
+  }
+
+  async function sendInterview(text: string) {
+    if (!projectId) return;
+    setError(null);
+    setReplying(true);
+    setMessages((current) => [...current, { role: "user", content: text }]);
+    setStreaming("");
+    try {
+      const reply = await streamInterview(
+        projectId,
+        text,
+        (delta) => setStreaming((value) => value + delta),
+        (items) => setResearched((current) => [...current, ...items]),
+      );
+      setStreaming("");
+      setMessages((current) => [...current, reply]);
+    } catch (e) {
+      setStreaming("");
+      setError(
+        e instanceof Error ? e.message : "Could not continue the briefing.",
+      );
+    } finally {
+      setReplying(false);
+    }
+  }
+
+  async function generateWorkspace() {
+    if (!projectId) {
+      setError("Pick a purpose first.");
+      return;
+    }
+    setGenerating(true);
+    setError(null);
+    try {
+      const project = await completeProject(projectId);
+      setWorkspaceName(project.name);
+      setBriefing(project.briefing);
+      setGoals(project.goals ?? []);
+      setSubreddits(project.subreddits ?? []);
+      setKeywords(project.keywords ?? []);
+      setStep(5);
+      await persistAccount(5);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Could not generate the workspace.",
+      );
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function finish() {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await patchProject(projectId, {
+        name: workspaceName,
+        briefing,
+        goals,
+        subreddits,
+        keywords,
+        complete: true,
+      });
+      await setActiveProject(projectId);
+      if (!isNewProject) {
+        await persistAccount(STEPS.length - 1);
+        await putConfig({ onboarding_complete: true });
+      }
       try {
         await fetchThreads();
       } catch {
@@ -255,10 +358,6 @@ export function OnboardingFlow() {
 
   async function handleContinue() {
     if (step === 0) {
-      if (!clientId.trim() && !clientSecret.trim() && !hasClientId) {
-        setError("Paste your Reddit client ID and secret to continue.");
-        return;
-      }
       if ((!clientId.trim() || !clientSecret.trim()) && !hasClientId) {
         setError("Paste your Reddit client ID and secret to continue.");
         return;
@@ -268,29 +367,37 @@ export function OnboardingFlow() {
       setError("Connect Reddit before continuing.");
       return;
     }
-    if (step === 2 && !productDesc.trim()) {
-      setError("Say a bit about what you make so we can suggest communities.");
+    if (step === 2 && !hasApiKey && !apiKey.trim()) {
+      setError("Add an LLM API key so we can draft and run the briefing.");
       return;
     }
-    if (step === 3 && !hasApiKey && !apiKey.trim()) {
-      setError("Add an LLM API key so we can draft and suggest subreddits.");
+    if (step === 3 && !purpose) {
+      setError("Choose what this workspace is for.");
       return;
     }
-    if (step === 4 && subreddits.length === 0) {
-      setError("Add at least one subreddit to continue.");
+    if (step === 4) {
+      await generateWorkspace();
       return;
     }
+    if (step === 5) {
+      if (subreddits.length === 0) {
+        setError("Add at least one subreddit to continue.");
+        return;
+      }
+      await finish();
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
       await saveSecretsIfPresent();
-      if (step < STEPS.length - 1) {
-        const nextStep = step + 1;
-        await persist(nextStep);
-        setStep(nextStep);
-        return;
+      if (step === 3 && purpose) {
+        await startInterview(purpose);
       }
-      await finish();
+      const nextStep = step + 1;
+      await persistAccount(nextStep);
+      setStep(nextStep);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not save this step.");
     } finally {
@@ -299,28 +406,17 @@ export function OnboardingFlow() {
   }
 
   async function handleBack() {
-    if (step === 0) return;
+    if (step <= firstVisible) {
+      if (isNewProject || isRerun) router.push("/queue");
+      return;
+    }
     const nextStep = step - 1;
     setError(null);
     try {
-      await persist(nextStep);
+      await persistAccount(nextStep);
       setStep(nextStep);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not save this step.");
-    }
-  }
-
-  async function handleConnect() {
-    setConnecting(true);
-    setError(null);
-    try {
-      await saveSecretsIfPresent();
-      await persist(1);
-      const { authorize_url } = await startOAuth("/onboarding");
-      window.location.href = authorize_url;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not start Reddit sign-in.");
-      setConnecting(false);
     }
   }
 
@@ -332,14 +428,20 @@ export function OnboardingFlow() {
     );
   }
 
-  const current = STEPS[step];
+  const continueLabel =
+    step === 4
+      ? "Generate workspace"
+      : step === STEPS.length - 1
+        ? "Finish"
+        : "Continue";
+  const isInterview = step === 4;
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-surface">
-      <header className="flex items-center justify-between px-6 py-4">
+      <header className="flex shrink-0 items-center justify-between px-6 py-4">
         <MeuxeMark size={32} />
         <div className="flex items-center gap-1.5">
-          {STEPS.map((_, i) => (
+          {visibleSteps.map((i) => (
             <span
               key={i}
               className={cn(
@@ -352,20 +454,56 @@ export function OnboardingFlow() {
         <div className="w-8" />
       </header>
 
-      <main className="flex flex-1 flex-col items-center justify-center px-6 pb-24">
-        <div className="w-full max-w-[560px] text-center motion-safe:animate-rise-in">
-          <Mascot mood={current.mood} className="mx-auto mb-6" size={96} />
-          <p className="mb-2 text-[13px] text-ink-3">
-            Step {step + 1} of {STEPS.length}
+      <main
+        className={cn(
+          "flex min-h-0 flex-1 flex-col items-center px-6 pb-24",
+          isInterview ? "justify-stretch pt-1" : "justify-center",
+        )}
+      >
+        <div
+          className={cn(
+            "w-full motion-safe:animate-rise-in",
+            isInterview
+              ? "flex min-h-0 max-w-[640px] flex-1 flex-col"
+              : "max-w-[560px] text-center",
+          )}
+        >
+          {!isInterview && (
+            <Mascot mood={current.mood} className="mx-auto mb-6" size={96} />
+          )}
+          <p
+            className={cn(
+              "mb-2 text-[13px] text-ink-3",
+              isInterview && "text-center",
+            )}
+          >
+            Step {visibleSteps.indexOf(step) + 1} of {visibleSteps.length}
           </p>
-          <h1 className="text-[24px] font-semibold tracking-tight text-ink">
+          <h1
+            className={cn(
+              "text-[24px] font-semibold tracking-tight text-ink",
+              isInterview && "text-center text-[20px]",
+            )}
+          >
             {current.title}
           </h1>
-          <p className="mt-2 text-[15px] leading-relaxed text-ink-2">
+          <p
+            className={cn(
+              "mt-2 text-[15px] leading-relaxed text-ink-2",
+              isInterview && "text-center text-[14px]",
+            )}
+          >
             {current.subtitle}
           </p>
 
-          <div className="mt-8 space-y-4 text-left">
+          <div
+            className={cn(
+              "text-left",
+              isInterview
+                ? "mt-5 flex min-h-0 flex-1 flex-col"
+                : "mt-8 space-y-4",
+            )}
+          >
             {error && <Notice tone="clay">{error}</Notice>}
 
             {step === 0 && (
@@ -430,38 +568,6 @@ export function OnboardingFlow() {
 
             {step === 2 && (
               <>
-                <Field>
-                  <Label htmlFor="ob-product">What do you make?</Label>
-                  <Textarea
-                    id="ob-product"
-                    value={productDesc}
-                    onChange={(e) => setProductDesc(e.target.value)}
-                    rows={3}
-                  />
-                </Field>
-                <Field>
-                  <Label htmlFor="ob-tone">Tone</Label>
-                  <Input
-                    id="ob-tone"
-                    value={tone}
-                    onChange={(e) => setTone(e.target.value)}
-                    placeholder="Helpful, direct, no hype"
-                  />
-                </Field>
-                <Field>
-                  <Label htmlFor="ob-persona">Persona notes</Label>
-                  <Textarea
-                    id="ob-persona"
-                    value={persona}
-                    onChange={(e) => setPersona(e.target.value)}
-                    rows={2}
-                  />
-                </Field>
-              </>
-            )}
-
-            {step === 3 && (
-              <>
                 {hasApiKey && (
                   <Notice tone="sage">
                     An LLM key is already saved. Leave the key blank to keep it.
@@ -499,37 +605,77 @@ export function OnboardingFlow() {
               </>
             )}
 
+            {step === 3 && (
+              <div className="space-y-2">
+                {PURPOSES.map((item) => (
+                  <ChoiceCard
+                    key={item.id}
+                    title={item.title}
+                    description={item.description}
+                    selected={purpose === item.id}
+                    onSelect={() => setPurpose(item.id)}
+                  />
+                ))}
+              </div>
+            )}
+
             {step === 4 && (
+              <InterviewChat
+                messages={messages}
+                streaming={streaming}
+                researched={researched}
+                busy={replying}
+                disabled={replying || generating}
+                onSend={(text) => void sendInterview(text)}
+              />
+            )}
+
+            {step === 5 && (
               <>
                 <Field>
-                  <div className="mb-1.5 flex items-center justify-between gap-2">
-                    <Label htmlFor="ob-subs">Subreddits</Label>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      leading={<IconRefresh size={14} />}
-                      loading={suggesting}
-                      onClick={() => void runSuggest(true)}
-                    >
-                      Regenerate
-                    </Button>
-                  </div>
+                  <Label htmlFor="ob-name">Workspace name</Label>
+                  <Input
+                    id="ob-name"
+                    value={workspaceName}
+                    onChange={(e) => setWorkspaceName(e.target.value)}
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="ob-briefing">
+                    {purpose === "personal"
+                      ? "About you"
+                      : purpose === "custom"
+                        ? "Aim"
+                        : "Product"}
+                  </Label>
+                  <Textarea
+                    id="ob-briefing"
+                    value={briefing}
+                    onChange={(e) => setBriefing(e.target.value)}
+                    rows={4}
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="ob-goals">Goals</Label>
+                  <TagInput
+                    id="ob-goals"
+                    values={goals}
+                    onChange={setGoals}
+                    placeholder="Add a goal and press Enter"
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="ob-subs">Subreddits</Label>
                   <TagInput
                     id="ob-subs"
                     values={subreddits}
                     onChange={setSubreddits}
                     stripSubPrefix
-                    disabled={suggesting}
-                    placeholder={
-                      suggesting
-                        ? "Suggesting communities…"
-                        : "Add r/name and press Enter"
-                    }
+                    placeholder="Add r/name and press Enter"
                   />
                   <Hint>
-                    Suggested from your product voice. Click a chip’s × to
-                    remove, or type to add.
+                    Suggested from the briefing. Add or remove until it feels
+                    right.
                   </Hint>
                 </Field>
                 <Field>
@@ -540,12 +686,9 @@ export function OnboardingFlow() {
                     onChange={setKeywords}
                     placeholder="Add a keyword and press Enter"
                   />
-                  <Hint>
-                    Signals for Discover — e.g. “looking for”, “recommend”.
-                  </Hint>
                 </Field>
                 <Notice tone="accent">
-                  We&apos;ll run your first thread fetch when you finish.
+                  We’ll run your first thread fetch when you finish.
                 </Notice>
               </>
             )}
@@ -554,11 +697,18 @@ export function OnboardingFlow() {
       </main>
 
       <footer className="fixed bottom-0 left-0 right-0 flex items-center justify-between border-t border-line bg-surface px-6 py-4">
-        <Button variant="ghost" disabled={step === 0} onClick={handleBack}>
-          Back
+        <Button
+          variant="ghost"
+          disabled={step <= firstVisible && !isNewProject && !isRerun}
+          onClick={() => void handleBack()}
+        >
+          {step <= firstVisible && (isNewProject || isRerun) ? "Cancel" : "Back"}
         </Button>
-        <Button loading={loading} onClick={handleContinue}>
-          {step === STEPS.length - 1 ? "Finish" : "Continue"}
+        <Button
+          loading={loading || generating}
+          onClick={() => void handleContinue()}
+        >
+          {continueLabel}
         </Button>
       </footer>
     </div>

--- a/web/src/components/onboarding/onboarding-flow.tsx
+++ b/web/src/components/onboarding/onboarding-flow.tsx
@@ -290,6 +290,11 @@ export function OnboardingFlow() {
       );
       setStreaming("");
       setMessages((current) => [...current, reply]);
+      if (reply.ready) {
+        setReplying(false);
+        await generateWorkspace();
+        return;
+      }
     } catch (e) {
       setStreaming("");
       setError(
@@ -624,7 +629,8 @@ export function OnboardingFlow() {
                 messages={messages}
                 streaming={streaming}
                 researched={researched}
-                busy={replying}
+                busy={replying || generating}
+                setup={generating}
                 disabled={replying || generating}
                 onSend={(text) => void sendInterview(text)}
               />

--- a/web/src/components/onboarding/onboarding-flow.tsx
+++ b/web/src/components/onboarding/onboarding-flow.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from "@/lib/cn";
 import { Button } from "@/components/ui/button";
 import { MeuxeMark, Mascot } from "@/components/ui/mascot";
+import { PageStatus } from "@/components/ui/page-status";
 import { Field, Label, Input, Textarea, Hint } from "@/components/ui/field";
 import { Notice } from "@/components/ui/notice";
 import { TagInput } from "@/components/ui/tag-input";
@@ -428,7 +429,7 @@ export function OnboardingFlow() {
   if (!ready) {
     return (
       <div className="fixed inset-0 z-40 flex items-center justify-center bg-surface">
-        <Mascot mood="thinking" />
+        <PageStatus kind="loading" message="Getting things ready…" />
       </div>
     );
   }
@@ -462,7 +463,9 @@ export function OnboardingFlow() {
       <main
         className={cn(
           "flex min-h-0 flex-1 flex-col items-center px-6 pb-24",
-          isInterview ? "justify-stretch pt-1" : "justify-center",
+          isInterview
+            ? "justify-stretch pt-1"
+            : "overflow-y-auto justify-start py-2",
         )}
       >
         <div

--- a/web/src/components/onboarding/onboarding-flow.tsx
+++ b/web/src/components/onboarding/onboarding-flow.tsx
@@ -15,6 +15,7 @@ import {
   startOAuth,
   streamInterview,
   type InterviewMessage,
+  type Project,
   type ProjectLink,
   type ProjectPurpose,
 } from "@/lib/api";
@@ -104,6 +105,22 @@ function messagesWithOpening(
   return [{ role: "assistant", content: OPENINGS[purpose] }, ...messages];
 }
 
+function workspaceStep(project: Project, fallback: number): number {
+  const saved = project.setup_step ?? 0;
+  if (saved === 3 || saved === 4 || saved === 5) return saved;
+  if (
+    (project.briefing || "").trim() &&
+    (project.subreddits?.length ?? 0) > 0 &&
+    !project.complete
+  ) {
+    return 5;
+  }
+  if ((project.interview_messages ?? []).some((item) => item.role === "user")) {
+    return 4;
+  }
+  return fallback;
+}
+
 function clampStep(value: number | undefined, max: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(Math.trunc(value as number), max));
@@ -153,8 +170,23 @@ export function OnboardingFlow() {
 
   useEffect(() => {
     let cancelled = false;
+
+    function hydrate(project: Project) {
+      setProjectId(project.id);
+      setPurpose(project.purpose);
+      setMessages(
+        messagesWithOpening(project.purpose, project.interview_messages ?? []),
+      );
+      setResearched(project.links ?? []);
+      setWorkspaceName(project.name);
+      setBriefing(project.briefing);
+      setGoals(project.goals ?? []);
+      setSubreddits(project.subreddits ?? []);
+      setKeywords(project.keywords ?? []);
+    }
+
     getConfig()
-      .then((config) => {
+      .then(async (config) => {
         if (cancelled) return;
         if (config.oauth_redirect_uri) setRedirectUri(config.oauth_redirect_uri);
         const account = config.accounts?.[0];
@@ -174,28 +206,39 @@ export function OnboardingFlow() {
 
         const reddit = searchParams.get("reddit");
         let nextStep = clampStep(config.onboarding_step, STEPS.length - 1);
+        let project = config.setup_project ?? null;
+
         if (isRerun && readyAccount && config.active_project_id) {
-          nextStep = 4;
-          void getProject(config.active_project_id)
-            .then((project) => {
+          if (!project || project.id !== config.active_project_id) {
+            project = await getProject(config.active_project_id);
+          }
+          if (cancelled) return;
+          if (project) {
+            if ((project.setup_step ?? 0) === 0) {
+              await patchProject(project.id, { setup_step: 4 });
               if (cancelled) return;
-              setProjectId(project.id);
-              setPurpose(project.purpose);
-              setMessages(
-                messagesWithOpening(
-                  project.purpose,
-                  project.interview_messages ?? [],
-                ),
-              );
-              setResearched(project.links ?? []);
-            })
-            .catch(() => {
-              if (!cancelled) setError("Could not load this workspace.");
-            });
+              project = { ...project, setup_step: 4 };
+            }
+            hydrate(project);
+            nextStep = workspaceStep(project, 4);
+          } else {
+            nextStep = 4;
+          }
         } else if (isNewProject && readyAccount) {
-          nextStep = ACCOUNT_STEPS;
-        } else if (readyAccount && nextStep < ACCOUNT_STEPS) {
-          nextStep = ACCOUNT_STEPS;
+          if (project) {
+            hydrate(project);
+            nextStep = workspaceStep(project, ACCOUNT_STEPS);
+          } else {
+            nextStep = ACCOUNT_STEPS;
+          }
+        } else {
+          if (readyAccount && nextStep < ACCOUNT_STEPS) {
+            nextStep = ACCOUNT_STEPS;
+          }
+          if (project) {
+            hydrate(project);
+            nextStep = Math.max(nextStep, workspaceStep(project, nextStep));
+          }
         }
         if (reddit === "connected" || reddit === "error") {
           nextStep = Math.max(nextStep, 1);
@@ -227,6 +270,13 @@ export function OnboardingFlow() {
         base_url: llmBaseUrl || undefined,
       },
     });
+  }
+
+  async function persistSetup(nextStep: number) {
+    await persistAccount(nextStep);
+    if (projectId && nextStep >= ACCOUNT_STEPS) {
+      await patchProject(projectId, { setup_step: nextStep });
+    }
   }
 
   async function saveSecretsIfPresent() {
@@ -321,7 +371,7 @@ export function OnboardingFlow() {
       setSubreddits(project.subreddits ?? []);
       setKeywords(project.keywords ?? []);
       setStep(5);
-      await persistAccount(5);
+      await persistSetup(5);
     } catch (e) {
       setError(
         e instanceof Error ? e.message : "Could not generate the workspace.",
@@ -381,10 +431,6 @@ export function OnboardingFlow() {
       setError("Choose what this workspace is for.");
       return;
     }
-    if (step === 4) {
-      await generateWorkspace();
-      return;
-    }
     if (step === 5) {
       if (subreddits.length === 0) {
         setError("Add at least one subreddit to continue.");
@@ -402,7 +448,7 @@ export function OnboardingFlow() {
         await startInterview(purpose);
       }
       const nextStep = step + 1;
-      await persistAccount(nextStep);
+      await persistSetup(nextStep);
       setStep(nextStep);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not save this step.");
@@ -419,7 +465,7 @@ export function OnboardingFlow() {
     const nextStep = step - 1;
     setError(null);
     try {
-      await persistAccount(nextStep);
+      await persistSetup(nextStep);
       setStep(nextStep);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not save this step.");
@@ -434,12 +480,7 @@ export function OnboardingFlow() {
     );
   }
 
-  const continueLabel =
-    step === 4
-      ? "Generate workspace"
-      : step === STEPS.length - 1
-        ? "Finish"
-        : "Continue";
+  const continueLabel = step === STEPS.length - 1 ? "Finish" : "Continue";
   const isInterview = step === 4;
 
   return (
@@ -708,17 +749,23 @@ export function OnboardingFlow() {
       <footer className="fixed bottom-0 left-0 right-0 flex items-center justify-between border-t border-line bg-surface px-6 py-4">
         <Button
           variant="ghost"
-          disabled={step <= firstVisible && !isNewProject && !isRerun}
+          disabled={
+            generating || (step <= firstVisible && !isNewProject && !isRerun)
+          }
           onClick={() => void handleBack()}
         >
           {step <= firstVisible && (isNewProject || isRerun) ? "Cancel" : "Back"}
         </Button>
-        <Button
-          loading={loading || generating}
-          onClick={() => void handleContinue()}
-        >
-          {continueLabel}
-        </Button>
+        {!isInterview ? (
+          <Button
+            loading={loading || generating}
+            onClick={() => void handleContinue()}
+          >
+            {continueLabel}
+          </Button>
+        ) : (
+          <div className="w-8" />
+        )}
       </footer>
     </div>
   );

--- a/web/src/components/posts/posts-view.tsx
+++ b/web/src/components/posts/posts-view.tsx
@@ -16,8 +16,7 @@ import { Button } from "@/components/ui/button";
 import { ApiDownNotice, Notice } from "@/components/ui/notice";
 import { Pill } from "@/components/ui/pill";
 import { Surface } from "@/components/ui/surface";
-import { Mascot } from "@/components/ui/mascot";
-import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { PageStatus } from "@/components/ui/page-status";
 import { IconDraft, IconPlus } from "@/components/ui/icons";
 import { BestTimeChips } from "@/components/schedule/best-time-chips";
 import { Field, Input, Label } from "@/components/ui/field";
@@ -170,19 +169,20 @@ export function PostsView() {
         {error && <Notice tone="clay">{error}</Notice>}
         {message && <Notice tone="sage">{message}</Notice>}
 
-        {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Mascot mood="thinking" />
-          </div>
+        {loading || busy === "generate" ? (
+          <PageStatus
+            kind="loading"
+            message={
+              busy === "generate"
+                ? "Drafting posts for your communities…"
+                : "Loading posts…"
+            }
+          />
         ) : drafts.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <AsciiAccent className="mb-4" />
-            <Mascot mood="neutral" className="mb-4" />
-            <p className="max-w-md text-[15px] text-ink-2">
-              No pending posts yet. Write one manually, or generate a batch for
-              your configured subreddits.
-            </p>
-          </div>
+          <PageStatus
+            kind="empty"
+            message="No pending posts yet. Write one manually, or generate a batch for your configured subreddits."
+          />
         ) : (
           <div className="space-y-3">
             {drafts.map((draft) => (

--- a/web/src/components/queue/queue-view.tsx
+++ b/web/src/components/queue/queue-view.tsx
@@ -8,8 +8,7 @@ import {
   type DraftStatus,
 } from "@/lib/api";
 import { ApiDownNotice } from "@/components/ui/notice";
-import { Mascot } from "@/components/ui/mascot";
-import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { PageStatus } from "@/components/ui/page-status";
 import { DraftCard, FilterChips } from "@/components/queue/draft-card";
 
 export function QueueView() {
@@ -62,17 +61,12 @@ export function QueueView() {
 
       <div className="flex-1 overflow-y-auto px-6 py-4">
         {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Mascot mood="thinking" />
-          </div>
+          <PageStatus kind="loading" message="Loading the queue…" />
         ) : drafts.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center motion-safe:animate-rise-in">
-            <AsciiAccent className="mb-4" />
-            <Mascot mood="neutral" className="mb-4" />
-            <p className="max-w-sm text-[15px] text-ink-2 leading-relaxed">
-              Nothing to review yet. Add threads from Discover.
-            </p>
-          </div>
+          <PageStatus
+            kind="empty"
+            message="Nothing to review yet. Add threads from Discover."
+          />
         ) : (
           <div className="grid gap-3 motion-safe:animate-fade-in">
             {drafts.map((draft) => (

--- a/web/src/components/schedule/schedule-view.tsx
+++ b/web/src/components/schedule/schedule-view.tsx
@@ -18,8 +18,8 @@ import { ApiDownNotice } from "@/components/ui/notice";
 import { Pill } from "@/components/ui/pill";
 import { Surface } from "@/components/ui/surface";
 import { Field, Label, Input } from "@/components/ui/field";
-import { Mascot } from "@/components/ui/mascot";
 import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { PageStatus } from "@/components/ui/page-status";
 import { BestTimeChips } from "@/components/schedule/best-time-chips";
 import { IconPlus } from "@/components/ui/icons";
 import { SubredditName } from "@/components/ui/subreddit-name";
@@ -117,23 +117,18 @@ export function ScheduleView() {
         {apiDown && <ApiDownNotice />}
 
         {loading ? (
-          <div className="flex items-center justify-center py-20">
-            <Mascot mood="thinking" />
-          </div>
+          <PageStatus kind="loading" message="Loading the schedule…" />
         ) : items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <AsciiAccent className="mb-4" />
-            <Mascot mood="neutral" className="mb-4" />
-            <p className="max-w-sm text-[15px] text-ink-2">
-              Nothing scheduled yet. Schedule a reply from the queue, or compose
-              an original post.
-            </p>
+          <PageStatus
+            kind="empty"
+            message="Nothing scheduled yet. Schedule a reply from the queue, or compose an original post."
+          >
             <Link href="/compose" className="mt-4">
               <Button variant="secondary" leading={<IconPlus size={16} />}>
                 New post
               </Button>
             </Link>
-          </div>
+          </PageStatus>
         ) : (
           Array.from(grouped.entries()).map(([day, dayItems]) => (
             <section key={day}>

--- a/web/src/components/shell/app-shell.tsx
+++ b/web/src/components/shell/app-shell.tsx
@@ -6,11 +6,18 @@ import { SettingsSheet } from "./settings-sheet";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [workspaceKey, setWorkspaceKey] = useState("default");
 
   return (
     <div className="flex h-screen gap-3 p-3 bg-canvas">
-      <Rail onSettingsOpen={() => setSettingsOpen(true)} />
-      <main className="flex min-w-0 flex-1 flex-col rounded-panel bg-surface shadow-soft squircle overflow-hidden">
+      <Rail
+        onSettingsOpen={() => setSettingsOpen(true)}
+        onProjectChange={(id) => setWorkspaceKey(id)}
+      />
+      <main
+        key={workspaceKey}
+        className="flex min-w-0 flex-1 flex-col rounded-panel bg-surface shadow-soft squircle overflow-hidden"
+      >
         {children}
       </main>
       <SettingsSheet open={settingsOpen} onClose={() => setSettingsOpen(false)} />

--- a/web/src/components/shell/conditional-shell.tsx
+++ b/web/src/components/shell/conditional-shell.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { AppShell } from "@/components/shell/app-shell";
 import { getConfig } from "@/lib/api";
-import { Mascot } from "@/components/ui/mascot";
+import { PageStatus } from "@/components/ui/page-status";
 
 export function ConditionalShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -44,7 +44,7 @@ export function ConditionalShell({ children }: { children: React.ReactNode }) {
   if (!allowed) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-canvas">
-        <Mascot mood="thinking" />
+        <PageStatus kind="loading" message="Opening Reddit Copilot…" />
       </div>
     );
   }

--- a/web/src/components/shell/project-switcher.tsx
+++ b/web/src/components/shell/project-switcher.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  listProjects,
+  setActiveProject,
+  type ProjectSummary,
+} from "@/lib/api";
+import { cn } from "@/lib/cn";
+import { IconPlus } from "@/components/ui/icons";
+
+export function ProjectSwitcher({
+  onChanged,
+}: {
+  onChanged?: (id: string) => void;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [activeId, setActiveId] = useState("");
+  const root = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listProjects()
+      .then((data) => {
+        if (cancelled) return;
+        setProjects(data.projects ?? []);
+        setActiveId(data.active_project_id ?? "");
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setProjects([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(event: MouseEvent) {
+      if (!root.current?.contains(event.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const active =
+    projects.find((item) => item.id === activeId) ?? projects[0] ?? null;
+  const initial = (active?.name || "W").trim().charAt(0).toUpperCase() || "W";
+
+  async function switchTo(id: string) {
+    if (id === activeId) {
+      setOpen(false);
+      return;
+    }
+    await setActiveProject(id);
+    setActiveId(id);
+    setOpen(false);
+    onChanged?.(id);
+  }
+
+  return (
+    <div ref={root} className="relative mb-4">
+      <button
+        type="button"
+        aria-label={active ? `Workspace ${active.name}` : "Workspaces"}
+        title={active?.name || "Workspaces"}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-control text-[13px] font-semibold text-ink",
+          "bg-surface-2 shadow-float transition-colors hover:bg-surface",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-200 squircle",
+        )}
+      >
+        {initial}
+      </button>
+      {open && (
+        <div className="absolute left-14 top-0 z-30 w-56 rounded-card bg-surface p-1.5 shadow-pop squircle">
+          <p className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-ink-3">
+            Workspaces
+          </p>
+          <div className="max-h-64 space-y-0.5 overflow-y-auto">
+            {projects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                onClick={() => void switchTo(project.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-control px-2 py-2 text-left text-[13px]",
+                  project.id === activeId
+                    ? "bg-accent-50 text-ink font-medium"
+                    : "text-ink-2 hover:bg-well hover:text-ink",
+                )}
+              >
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-control bg-well text-[11px] font-semibold text-ink">
+                  {(project.name || "W").trim().charAt(0).toUpperCase()}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              router.push("/onboarding?new=1");
+            }}
+            className="mt-1 flex w-full items-center gap-2 rounded-control px-2 py-2 text-left text-[13px] text-ink-2 hover:bg-well hover:text-ink"
+          >
+            <IconPlus size={14} />
+            New project
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/shell/rail.tsx
+++ b/web/src/components/shell/rail.tsx
@@ -14,6 +14,8 @@ import {
   IconPosts,
 } from "@/components/ui/icons";
 
+import { ProjectSwitcher } from "./project-switcher";
+
 const navItems = [
   { href: "/queue", label: "Queue", icon: IconQueue },
   { href: "/discover", label: "Discover", icon: IconCompass },
@@ -22,7 +24,13 @@ const navItems = [
   { href: "/activity", label: "Activity", icon: IconActivity },
 ];
 
-export function Rail({ onSettingsOpen }: { onSettingsOpen: () => void }) {
+export function Rail({
+  onSettingsOpen,
+  onProjectChange,
+}: {
+  onSettingsOpen: () => void;
+  onProjectChange?: (id: string) => void;
+}) {
   const pathname = usePathname();
 
   return (
@@ -30,9 +38,10 @@ export function Rail({ onSettingsOpen }: { onSettingsOpen: () => void }) {
       className="flex h-full w-16 shrink-0 flex-col items-center bg-well py-3 squircle rounded-panel"
       aria-label="Main navigation"
     >
-      <Link href="/queue" className="mb-6" aria-label="Reddit Copilot home">
+      <Link href="/queue" className="mb-3" aria-label="Reddit Copilot home">
         <MeuxeMark size={48} />
       </Link>
+      <ProjectSwitcher onChanged={onProjectChange} />
 
       <div className="flex flex-1 flex-col items-center gap-1">
         {navItems.map(({ href, label, icon: Icon }) => {

--- a/web/src/components/shell/settings-sheet.tsx
+++ b/web/src/components/shell/settings-sheet.tsx
@@ -17,7 +17,8 @@ import { IconButton } from "@/components/ui/icon-button";
 import { IconRefresh, IconX } from "@/components/ui/icons";
 import { Field, Label, Input, Textarea, Hint } from "@/components/ui/field";
 import { Notice } from "@/components/ui/notice";
-import { MeuxeMark, Mascot } from "@/components/ui/mascot";
+import { MeuxeMark } from "@/components/ui/mascot";
+import { PageStatus } from "@/components/ui/page-status";
 import { TagInput } from "@/components/ui/tag-input";
 
 const sections = [
@@ -253,9 +254,12 @@ export function SettingsSheet({
             )}
 
             {!loaded && (
-              <div className="flex h-full items-center justify-center py-16">
-                <Mascot mood="thinking" size={72} />
-              </div>
+              <PageStatus
+                kind="loading"
+                message="Loading settings…"
+                size={72}
+                className="h-full py-16"
+              />
             )}
 
             {loaded && section === "accounts" && (

--- a/web/src/components/shell/settings-sheet.tsx
+++ b/web/src/components/shell/settings-sheet.tsx
@@ -9,6 +9,7 @@ import {
   startOAuth,
   suggestSubreddits,
   type AppConfig,
+  type ProjectPurpose,
   type SecretsUpdate,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -59,6 +60,8 @@ export function SettingsSheet({
   const [tone, setTone] = useState("");
   const [persona, setPersona] = useState("");
   const [avoid, setAvoid] = useState("");
+  const [goals, setGoals] = useState<string[]>([]);
+  const [purpose, setPurpose] = useState<ProjectPurpose>("product");
   const [subreddits, setSubreddits] = useState<string[]>([]);
   const [keywords, setKeywords] = useState<string[]>([]);
   const [dailyCap, setDailyCap] = useState("");
@@ -87,6 +90,8 @@ export function SettingsSheet({
         setTone(c.voice?.tone ?? "");
         setPersona(c.voice?.persona ?? "");
         setAvoid(c.voice?.avoid ?? "");
+        setGoals(c.goals ?? []);
+        setPurpose(c.purpose ?? "product");
         setSubreddits(c.subreddits ?? []);
         setKeywords(c.discovery?.keywords ?? []);
         setSearchQueries((c.discovery?.search_queries ?? []).join("\n"));
@@ -136,6 +141,8 @@ export function SettingsSheet({
           persona,
           avoid,
         },
+        goals,
+        purpose,
         discovery: {
           keywords,
         },
@@ -317,12 +324,27 @@ export function SettingsSheet({
             {loaded && section === "voice" && (
               <>
                 <Field>
-                  <Label htmlFor="product-desc">Product description</Label>
+                  <Label htmlFor="product-desc">
+                    {purpose === "personal"
+                      ? "About you"
+                      : purpose === "custom"
+                        ? "Aim"
+                        : "Product description"}
+                  </Label>
                   <Textarea
                     id="product-desc"
                     value={productDesc}
                     onChange={(e) => setProductDesc(e.target.value)}
                     rows={4}
+                  />
+                </Field>
+                <Field>
+                  <Label htmlFor="goals">Goals</Label>
+                  <TagInput
+                    id="goals"
+                    values={goals}
+                    onChange={setGoals}
+                    placeholder="Add a goal and press Enter"
                   />
                 </Field>
                 <Field>
@@ -352,6 +374,20 @@ export function SettingsSheet({
                     placeholder="Hard sells, hype, asking for upvotes"
                   />
                 </Field>
+                <div className="flex flex-wrap gap-4">
+                  <a
+                    href="/onboarding?briefing=1"
+                    className="inline-flex text-[13px] text-ink-2 underline-offset-2 hover:text-ink hover:underline"
+                  >
+                    Re-run briefing
+                  </a>
+                  <a
+                    href="/onboarding?new=1"
+                    className="inline-flex text-[13px] text-ink-2 underline-offset-2 hover:text-ink hover:underline"
+                  >
+                    New project
+                  </a>
+                </div>
               </>
             )}
 
@@ -374,6 +410,8 @@ export function SettingsSheet({
                             product: productDesc,
                             tone,
                             persona,
+                            purpose,
+                            goals,
                           });
                           setSubreddits(data.subreddits ?? []);
                         } catch (e) {
@@ -418,7 +456,7 @@ export function SettingsSheet({
                       rows={6}
                     />
                     <Hint>
-                      Generated from your product and keywords. Refreshed on fetch
+                      Generated from your briefing and keywords. Refreshed on fetch
                       when those change.
                     </Hint>
                   </Field>

--- a/web/src/components/ui/icons.tsx
+++ b/web/src/components/ui/icons.tsx
@@ -126,10 +126,10 @@ export function IconChevronLeft(props: IconProps) {
   );
 }
 
-export function IconChevronRight(props: IconProps) {
+export function IconChevronDown(props: IconProps) {
   return (
     <Icon {...props}>
-      <path d="M10 6l6 6-6 6" />
+      <path d="M6 9l6 6 6-6" />
     </Icon>
   );
 }

--- a/web/src/components/ui/markdown.tsx
+++ b/web/src/components/ui/markdown.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { Components } from "react-markdown";
+import Markdown from "react-markdown";
+import { cn } from "@/lib/cn";
+
+const components: Components = {
+  p: ({ children }) => (
+    <p className="mb-2 last:mb-0 text-[14px] leading-[1.55]">{children}</p>
+  ),
+  strong: ({ children }) => (
+    <strong className="font-semibold text-ink">{children}</strong>
+  ),
+  em: ({ children }) => <em className="italic">{children}</em>,
+  ul: ({ children }) => (
+    <ul className="mb-2 list-disc last:mb-0 space-y-1 pl-4 marker:text-ink-3">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="mb-2 list-decimal last:mb-0 space-y-1 pl-4 marker:text-ink-3">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => (
+    <li className="text-[14px] leading-[1.55]">{children}</li>
+  ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="text-ink underline decoration-accent-300 underline-offset-2 hover:decoration-accent-400"
+    >
+      {children}
+    </a>
+  ),
+  code: ({ children, className }) => {
+    const block = Boolean(className);
+    if (block) {
+      return (
+        <code className="block overflow-x-auto rounded-field bg-well px-3 py-2 font-mono text-[12px] text-ink-2">
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code className="rounded-[6px] bg-well px-1 py-0.5 font-mono text-[12.5px] text-ink">
+        {children}
+      </code>
+    );
+  },
+  pre: ({ children }) => <pre className="mb-2 last:mb-0">{children}</pre>,
+  h1: ({ children }) => (
+    <p className="mb-2 text-[15px] font-semibold tracking-tight last:mb-0">
+      {children}
+    </p>
+  ),
+  h2: ({ children }) => (
+    <p className="mb-2 text-[15px] font-semibold tracking-tight last:mb-0">
+      {children}
+    </p>
+  ),
+  h3: ({ children }) => (
+    <p className="mb-2 text-[14px] font-semibold tracking-tight last:mb-0">
+      {children}
+    </p>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="mb-2 border-l-2 border-accent-300 pl-3 text-ink-2 last:mb-0">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-3 border-line" />,
+};
+
+export function MarkdownBody({
+  text,
+  className,
+  tone = "agent",
+}: {
+  text: string;
+  className?: string;
+  tone?: "agent" | "user";
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0",
+        tone === "user"
+          ? "text-white [&_p]:text-white [&_strong]:text-white [&_em]:text-white [&_li]:text-white [&_a]:text-accent-200 [&_code]:bg-white/15 [&_code]:text-white [&_blockquote]:border-accent-300 [&_blockquote]:text-white/90"
+          : "text-ink [&_p]:text-ink",
+        className,
+      )}
+    >
+      <Markdown components={components} skipHtml>
+        {text}
+      </Markdown>
+    </div>
+  );
+}

--- a/web/src/components/ui/mascot.tsx
+++ b/web/src/components/ui/mascot.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/cn";
 
 type MascotMood = "neutral" | "happy" | "thinking" | "sleepy" | "surprised";
@@ -24,21 +27,40 @@ const palettes = {
   mark: { outer: "#E2C78A", inner: "#EDD9A4" },
 } as const;
 
+const TALK_RY = [2.4, 5.4, 1.8, 4.6];
+
+function useTalkingMouth(active: boolean) {
+  const [frame, setFrame] = useState(1);
+  useEffect(() => {
+    if (!active) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const id = window.setInterval(() => {
+      setFrame((current) => (current + 1) % TALK_RY.length);
+    }, 115);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return TALK_RY[frame];
+}
+
 export function Mascot({
   mood = "neutral",
   size = 80,
   className,
   animate = true,
+  talking = false,
   palette = "soft",
 }: {
   mood?: MascotMood;
   size?: number;
   className?: string;
   animate?: boolean;
+  talking?: boolean;
   palette?: keyof typeof palettes;
 }) {
-  const ey = eyeY[mood];
+  const face = talking ? "happy" : mood;
+  const ey = eyeY[face];
   const fills = palettes[palette];
+  const talkRy = useTalkingMouth(talking);
 
   return (
     <svg
@@ -47,7 +69,10 @@ export function Mascot({
       viewBox="0 0 96 96"
       aria-hidden="true"
       className={cn(
-        animate && "motion-safe:animate-breathe",
+        animate &&
+          (talking
+            ? "motion-safe:animate-breathe-talk"
+            : "motion-safe:animate-breathe"),
         className,
       )}
     >
@@ -55,25 +80,27 @@ export function Mascot({
       <ellipse cx="48" cy="48" rx="34" ry="30" fill={fills.inner} />
       <circle cx="36" cy={ey} r="3.5" fill="#1B1B1E" className="motion-safe:animate-blink" style={{ transformOrigin: "36px 42px" }} />
       <circle cx="60" cy={ey} r="3.5" fill="#1B1B1E" className="motion-safe:animate-blink" style={{ transformOrigin: "60px 42px" }} />
-      {mood === "thinking" && (
+      {face === "thinking" && !talking && (
         <path d="M62 36 Q68 30 72 34" stroke="#E8B44A" strokeWidth="2" fill="none" strokeLinecap="round" />
       )}
-      {mood === "sleepy" && (
+      {face === "sleepy" && !talking && (
         <>
           <path d="M30 40 Q36 36 42 40" stroke="#1B1B1E" strokeWidth="1.6" fill="none" strokeLinecap="round" />
           <path d="M54 40 Q60 36 66 40" stroke="#1B1B1E" strokeWidth="1.6" fill="none" strokeLinecap="round" />
         </>
       )}
-      {mood !== "sleepy" && (
+      {talking ? (
+        <ellipse cx="48" cy="58.5" rx="6" ry={talkRy} fill="#1B1B1E" />
+      ) : face !== "sleepy" ? (
         <path
-          d={mouthPaths[mood]}
+          d={mouthPaths[face]}
           stroke="#1B1B1E"
           strokeWidth="1.6"
           fill="none"
           strokeLinecap="round"
         />
-      )}
-      {mood === "surprised" && (
+      ) : null}
+      {face === "surprised" && !talking && (
         <ellipse cx="48" cy="58" rx="4" ry="5" fill="none" stroke="#1B1B1E" strokeWidth="1.6" />
       )}
     </svg>

--- a/web/src/components/ui/mascot.tsx
+++ b/web/src/components/ui/mascot.tsx
@@ -48,6 +48,7 @@ export function Mascot({
   className,
   animate = true,
   talking = false,
+  searching = false,
   palette = "soft",
 }: {
   mood?: MascotMood;
@@ -55,6 +56,7 @@ export function Mascot({
   className?: string;
   animate?: boolean;
   talking?: boolean;
+  searching?: boolean;
   palette?: keyof typeof palettes;
 }) {
   const face = talking ? "happy" : mood;
@@ -67,10 +69,11 @@ export function Mascot({
       width={size}
       height={size}
       viewBox="0 0 96 96"
+      overflow="visible"
       aria-hidden="true"
       className={cn(
         animate &&
-          (talking
+          (talking || searching
             ? "motion-safe:animate-breathe-talk"
             : "motion-safe:animate-breathe"),
         className,
@@ -78,8 +81,31 @@ export function Mascot({
     >
       <ellipse cx="48" cy="52" rx="36" ry="32" fill={fills.outer} />
       <ellipse cx="48" cy="48" rx="34" ry="30" fill={fills.inner} />
-      <circle cx="36" cy={ey} r="3.5" fill="#1B1B1E" className="motion-safe:animate-blink" style={{ transformOrigin: "36px 42px" }} />
-      <circle cx="60" cy={ey} r="3.5" fill="#1B1B1E" className="motion-safe:animate-blink" style={{ transformOrigin: "60px 42px" }} />
+      <g
+        className={searching ? "motion-safe:animate-glance" : undefined}
+        style={
+          searching
+            ? { transformBox: "fill-box", transformOrigin: "center" }
+            : undefined
+        }
+      >
+        <circle
+          cx="36"
+          cy={ey}
+          r="3.5"
+          fill="#1B1B1E"
+          className={searching ? undefined : "motion-safe:animate-blink"}
+          style={{ transformOrigin: "36px 42px" }}
+        />
+        <circle
+          cx="60"
+          cy={ey}
+          r="3.5"
+          fill="#1B1B1E"
+          className={searching ? undefined : "motion-safe:animate-blink"}
+          style={{ transformOrigin: "60px 42px" }}
+        />
+      </g>
       {face === "thinking" && !talking && (
         <path d="M62 36 Q68 30 72 34" stroke="#E8B44A" strokeWidth="2" fill="none" strokeLinecap="round" />
       )}

--- a/web/src/components/ui/page-status.tsx
+++ b/web/src/components/ui/page-status.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+import { Mascot } from "@/components/ui/mascot";
+import { AsciiAccent } from "@/components/ui/ascii-accent";
+import { Dots } from "@/components/ui/dots";
+
+export function PageStatus({
+  kind,
+  message,
+  size = 96,
+  className,
+  children,
+}: {
+  kind: "loading" | "empty";
+  message: string;
+  size?: number;
+  className?: string;
+  children?: ReactNode;
+}) {
+  const loading = kind === "loading";
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 text-center motion-safe:animate-rise-in",
+        className,
+      )}
+      role="status"
+      aria-live="polite"
+      aria-busy={loading}
+    >
+      {!loading && <AsciiAccent className="mb-4" />}
+      <Mascot
+        mood={loading ? "thinking" : "sleepy"}
+        searching={loading}
+        size={size}
+        className="mb-4"
+      />
+      <p className="max-w-sm text-[15px] leading-relaxed text-ink-2">
+        {message}
+      </p>
+      {loading ? <Dots className="mt-4" /> : null}
+      {children}
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -61,6 +61,7 @@
   --animate-dot: dot 1.4s ease-in-out infinite;
   --animate-talk: talk 0.38s ease-in-out infinite;
   --animate-caret: caret 1s steps(1) infinite;
+  --animate-glance: glance 2.2s ease-in-out infinite;
 }
 
 @keyframes fade-in {
@@ -139,6 +140,20 @@
   50%,
   100% {
     opacity: 0;
+  }
+}
+
+@keyframes glance {
+  0%,
+  22%,
+  100% {
+    transform: translateX(0);
+  }
+  38% {
+    transform: translateX(-3.5px);
+  }
+  62% {
+    transform: translateX(3.5px);
   }
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -56,8 +56,11 @@
   --animate-rise-in: rise-in 350ms var(--ease-soft) both;
   --animate-pop-in: pop-in 300ms var(--ease-soft) both;
   --animate-breathe: breathe 4s ease-in-out infinite;
+  --animate-breathe-talk: breathe 1.15s ease-in-out infinite;
   --animate-blink: blink 4s ease-in-out infinite;
   --animate-dot: dot 1.4s ease-in-out infinite;
+  --animate-talk: talk 0.38s ease-in-out infinite;
+  --animate-caret: caret 1s steps(1) infinite;
 }
 
 @keyframes fade-in {
@@ -109,6 +112,33 @@
   }
   95% {
     transform: scaleY(0.1);
+  }
+}
+
+@keyframes talk {
+  0%,
+  100% {
+    transform: scaleY(0.32);
+  }
+  28% {
+    transform: scaleY(1);
+  }
+  48% {
+    transform: scaleY(0.42);
+  }
+  72% {
+    transform: scaleY(0.88);
+  }
+}
+
+@keyframes caret {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
   }
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,6 +126,51 @@ export interface AppConfig {
   oauth_redirect_uri: string;
   frontend_url: string;
   prompt_template?: string;
+  active_project_id?: string;
+  purpose?: ProjectPurpose;
+  goals?: string[];
+  projects?: ProjectSummary[];
+}
+
+export type ProjectPurpose = "product" | "personal" | "custom";
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  purpose: ProjectPurpose;
+  complete: boolean;
+}
+
+export interface ProjectLink {
+  url: string;
+  title?: string;
+  excerpt?: string;
+  ok?: boolean;
+  error?: string | null;
+}
+
+export interface InterviewMessage {
+  role: "assistant" | "user" | "system";
+  content: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  purpose: ProjectPurpose;
+  briefing: string;
+  goals: string[];
+  links: ProjectLink[];
+  interview_messages: InterviewMessage[];
+  tone: string;
+  persona: string;
+  avoid: string;
+  subreddits: string[];
+  keywords: string[];
+  search_queries: string[];
+  complete: boolean;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export type ConfigUpdate = {
@@ -141,6 +186,9 @@ export type ConfigUpdate = {
   prompt_template?: string;
   onboarding_complete?: boolean;
   onboarding_step?: number;
+  active_project_id?: string;
+  purpose?: ProjectPurpose;
+  goals?: string[];
 };
 
 export type SecretsUpdate = {
@@ -284,6 +332,8 @@ export function suggestSubreddits(input?: {
   tone?: string;
   persona?: string;
   count?: number;
+  purpose?: ProjectPurpose;
+  goals?: string[];
 }): Promise<{ subreddits: string[] }> {
   return request("/api/subreddits/suggest", {
     method: "POST",
@@ -292,6 +342,8 @@ export function suggestSubreddits(input?: {
       tone: input?.tone,
       persona: input?.persona,
       count: input?.count ?? 12,
+      purpose: input?.purpose,
+      goals: input?.goals,
     }),
   });
 }
@@ -472,4 +524,117 @@ export function startOAuth(
     method: "POST",
     body: JSON.stringify({ next, account_name: accountName }),
   });
+}
+
+export function listProjects(): Promise<{
+  projects: ProjectSummary[];
+  active_project_id: string;
+}> {
+  return request("/api/projects");
+}
+
+export function createProject(purpose: ProjectPurpose, name?: string): Promise<Project> {
+  return request("/api/projects", {
+    method: "POST",
+    body: JSON.stringify({ purpose, name }),
+  });
+}
+
+export function getProject(id: string): Promise<Project> {
+  return request(`/api/projects/${id}`);
+}
+
+export function patchProject(
+  id: string,
+  body: Partial<{
+    name: string;
+    briefing: string;
+    goals: string[];
+    tone: string;
+    persona: string;
+    avoid: string;
+    subreddits: string[];
+    keywords: string[];
+    complete: boolean;
+  }>,
+): Promise<Project> {
+  return request(`/api/projects/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export function setActiveProject(id: string): Promise<AppConfig> {
+  return request("/api/projects/active", {
+    method: "PUT",
+    body: JSON.stringify({ id }),
+  });
+}
+
+export function completeProject(id: string): Promise<Project> {
+  return request(`/api/projects/${id}/complete`, { method: "POST" });
+}
+
+export async function streamInterview(
+  projectId: string,
+  message: string,
+  onDelta: (delta: string) => void,
+  onResearch?: (items: ProjectLink[]) => void,
+): Promise<InterviewMessage> {
+  const res = await fetch(`/api/projects/${projectId}/interview`, {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    let messageText = `Request failed (${res.status})`;
+    try {
+      const data = (await res.json()) as { error?: string; detail?: string };
+      if (data.error) messageText = data.error;
+      else if (typeof data.detail === "string") messageText = data.detail;
+    } catch {
+      // ignore
+    }
+    throw new ApiError(messageText, res.status);
+  }
+  if (!res.body) {
+    throw new ApiError("No stream from API", res.status || 500);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let reply: InterviewMessage | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() ?? "";
+    for (const chunk of chunks) {
+      const line = chunk.split("\n").find((entry) => entry.startsWith("data: "));
+      if (!line) continue;
+      const payload = JSON.parse(line.slice(6)) as {
+        delta?: string;
+        done?: boolean;
+        message?: InterviewMessage;
+        research?: ProjectLink[];
+        error?: string;
+      };
+      if (payload.error) throw new ApiError(payload.error, 400);
+      if (payload.research?.length) onResearch?.(payload.research);
+      if (payload.delta) onDelta(payload.delta);
+      if (payload.done && payload.message) reply = payload.message;
+    }
+  }
+
+  if (!reply) {
+    throw new ApiError("Stream ended without a reply", 500);
+  }
+  return reply;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -152,6 +152,7 @@ export interface ProjectLink {
 export interface InterviewMessage {
   role: "assistant" | "user" | "system";
   content: string;
+  ready?: boolean;
 }
 
 export interface Project {
@@ -622,6 +623,7 @@ export async function streamInterview(
       const payload = JSON.parse(line.slice(6)) as {
         delta?: string;
         done?: boolean;
+        ready?: boolean;
         message?: InterviewMessage;
         research?: ProjectLink[];
         error?: string;
@@ -629,7 +631,9 @@ export async function streamInterview(
       if (payload.error) throw new ApiError(payload.error, 400);
       if (payload.research?.length) onResearch?.(payload.research);
       if (payload.delta) onDelta(payload.delta);
-      if (payload.done && payload.message) reply = payload.message;
+      if (payload.done && payload.message) {
+        reply = { ...payload.message, ready: Boolean(payload.ready) };
+      }
     }
   }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -130,6 +130,7 @@ export interface AppConfig {
   purpose?: ProjectPurpose;
   goals?: string[];
   projects?: ProjectSummary[];
+  setup_project?: Project | null;
 }
 
 export type ProjectPurpose = "product" | "personal" | "custom";
@@ -170,6 +171,7 @@ export interface Project {
   keywords: string[];
   search_queries: string[];
   complete: boolean;
+  setup_step?: number;
   created_at?: string;
   updated_at?: string;
 }
@@ -557,6 +559,7 @@ export function patchProject(
     subreddits: string[];
     keywords: string[];
     complete: boolean;
+    setup_step: number;
   }>,
 ): Promise<Project> {
   return request(`/api/projects/${id}`, {


### PR DESCRIPTION
## Summary
- Replace the single product voice with Product, Personal, and Custom project workspaces. Reddit OAuth and the LLM key stay account-level; each project owns briefing, goals, subreddits, drafts, and the queue.
- Onboarding now picks a purpose, runs an interview chat (SSE, URL research, markdown), then reviews the generated workspace. Later projects skip account setup via the rail switcher.
- Discovery, scoring, drafts, and the worker read from the active project briefing instead of `voice.product`.

## Test plan
- [ ] First-run onboarding: Reddit + LLM, then purpose → interview → review → first fetch
- [ ] New project from the rail (`/onboarding?new=1`) skips Reddit/LLM and does not steal the previous workspace if you cancel
- [ ] Switching projects remounts Queue / Discover / Posts / Schedule / Activity
- [ ] Settings Voice labels follow purpose (Product / About you / Aim); Re-run briefing opens the interview for the active project
- [ ] Interview chat: agent left with talking mascot while streaming, user right, markdown renders
- [ ] `python3 -m pytest tests/ -q`